### PR TITLE
Add changes to postgress scripts

### DIFF
--- a/components/org.wso2.is.migration/migration-resources/5.9.0/dbscripts/step1/identity/postgresql+9.6.sql
+++ b/components/org.wso2.is.migration/migration-resources/5.9.0/dbscripts/step1/identity/postgresql+9.6.sql
@@ -36,6 +36,6 @@ CREATE TABLE IF NOT EXISTS IDN_FUNCTION_LIBRARY (
 
 CREATE OR REPLACE FUNCTION skip_index_if_exists(indexName varchar(64),tableName varchar(64), tableColumns varchar(64))  RETURNS void AS $$ declare s varchar(1000);  begin if to_regclass(indexName) IS NULL then s :=  CONCAT('CREATE INDEX ' , indexName , ' ON ' , tableName, tableColumns);execute s;end if;END;$$ LANGUAGE plpgsql;
 
-SELECT skip_index_if_exists('IDX_FIDO2_STR','FIDO2_DEVICE_STORE','(USER_NAME, TENANT_ID, DOMAIN_NAME, CREDENTIAL_ID, USER_HANDLE)');
+SELECT skip_index_if_exists('idx_fido2_str','fido2_device_store','(user_name, tenant_id, domain_name, credential_id, user_handle)');
 
 DROP FUNCTION skip_index_if_exists;

--- a/components/org.wso2.is.migration/migration-resources/5.9.0/dbscripts/step1/identity/postgresql.sql
+++ b/components/org.wso2.is.migration/migration-resources/5.9.0/dbscripts/step1/identity/postgresql.sql
@@ -38,8 +38,8 @@ CREATE TABLE IDN_FUNCTION_LIBRARY (
       PRIMARY KEY (TENANT_ID,NAME)
 );
 
-CREATE OR REPLACE FUNCTION skip_index_if_exists(indexName varchar(64),tableName varchar(64), tableColumns varchar(64))  RETURNS void AS $$ declare s varchar(1000);  begin if to_regclass(indexName) IS NULL then s :=  CONCAT('CREATE INDEX ' , indexName , ' ON ' , tableName, tableColumns);execute s;end if;END;$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION skip_index_if_exists(nameOfTheIndex varchar(64),tableName varchar(64), tableColumns varchar(64)) RETURNS void AS $$ declare s varchar(1000); declare result INTEGER; begin SELECT COUNT(1) into result FROM pg_indexes WHERE indexname = nameOfTheIndex; IF result = 0 THEN s :=  CONCAT('CREATE INDEX ' , nameOfTheIndex , ' ON ' , tableName, tableColumns); execute s; end if; END;$$ LANGUAGE plpgsql;
 
-SELECT skip_index_if_exists('IDX_FIDO2_STR','FIDO2_DEVICE_STORE','(USER_NAME, TENANT_ID, DOMAIN_NAME, CREDENTIAL_ID, USER_HANDLE)');
+SELECT skip_index_if_exists('idx_fido2_str','fido2_device_store','(user_name, tenant_id, domain_name, credential_id, user_handle)');
 
 DROP FUNCTION skip_index_if_exists;


### PR DESCRIPTION
Fixes apply for issue on argument of to_regclass() and rename the  exiting scripts, postgresql+9.1.sql to postgresql+9.6.sql.  according to the fix applied in 5.8 migration,  https://github.com/wso2-extensions/identity-migration-resources/pull/21/