### PR TITLE
Fix SQL syntax error in identity data migration

### DIFF
--- a/components/org.wso2.is.migration/migration-resources/5.8.0/dbscripts/step1/identity/postgresql+9.6.sql
+++ b/components/org.wso2.is.migration/migration-resources/5.8.0/dbscripts/step1/identity/postgresql+9.6.sql
@@ -62,6 +62,6 @@ SELECT skip_index_if_exists('IDX_AUTH_USER_UN_TID_DN', 'IDN_AUTH_USER', '(USER_N
 
 SELECT skip_index_if_exists('IDX_AUTH_USER_DN_TOD', 'IDN_AUTH_USER', '(DOMAIN_NAME, TENANT_ID)');
 
-DROP FUNCTION skip_index_if_exists;
+DROP FUNCTION skip_index_if_exists(varchar,varchar,varchar);
 
-DROP FUNCTION add_idp_id_to_con_app_key_if_token_id_present;
+DROP FUNCTION add_idp_id_to_con_app_key_if_token_id_present();

--- a/components/org.wso2.is.migration/migration-resources/5.9.0/dbscripts/step1/identity/postgresql+9.6.sql
+++ b/components/org.wso2.is.migration/migration-resources/5.9.0/dbscripts/step1/identity/postgresql+9.6.sql
@@ -38,4 +38,4 @@ CREATE OR REPLACE FUNCTION skip_index_if_exists(indexName varchar(64),tableName 
 
 SELECT skip_index_if_exists('idx_fido2_str','fido2_device_store','(user_name, tenant_id, domain_name, credential_id, user_handle)');
 
-DROP FUNCTION skip_index_if_exists;
+DROP FUNCTION skip_index_if_exists(varchar,varchar,varchar);


### PR DESCRIPTION
## Purpose
SQL syntax error occurred during the execution of identity data migration scripts to drop the SQL function for PostgreSQL-v9.6.9. This PR will fix that error. 

>> [2020-03-31 07:18:35,993] ERROR - SchemaMigrator Error occurred while executing SQL script for migrating database
java.lang.Exception: Error occurred while executing :   DROP FUNCTION skip_index_if_exists
        at org.wso2.carbon.is.migration.service.SchemaMigrator.executeSQL(SchemaMigrator.java:303) ~[org.wso2.carbon.is.migration-1.0.79.jar:?]
        at org.wso2.carbon.is.migration.service.SchemaMigrator.executeSQLScript(SchemaMigrator.java:234) [org.wso2.carbon.is.migration-1.0.79.jar:?]
        at org.wso2.carbon.is.migration.service.SchemaMigrator.migrate(SchemaMigrator.java:89) [org.wso2.carbon.is.migration-1.0.79.jar:?]
        at org.wso2.carbon.is.migration.VersionMigration.migrate(VersionMigration.java:52) [org.wso2.carbon.is.migration-1.0.79.jar:?]
        at org.wso2.carbon.is.migration.MigrationClientImpl.execute(MigrationClientImpl.java:85) [org.wso2.carbon.is.migration-1.0.79.jar:?]
        at org.wso2.carbon.identity.core.internal.IdentityCoreServiceComponent.activate(IdentityCoreServiceComponent.java:147) [org.wso2.carbon.identity.core_5.14.97.jar:?]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_202]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_202]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_202]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_202]
        at org.eclipse.equinox.internal.ds.model.ServiceComponent.activate(ServiceComponent.java:260) [org.eclipse.equinox.ds_1.4.400.v20160226-2036.jar:?]
        at org.eclipse.equinox.internal.ds.model.ServiceComponentProp.activate(ServiceComponentProp.java:146) [org.eclipse.equinox.ds_1.4.400.v20160226-2036.jar:?]
        at org.eclipse.equinox.internal.ds.model.ServiceComponentProp.build(ServiceComponentProp.java:345) [org.eclipse.equinox.ds_1.4.400.v20160226-2036.jar:?]
        at org.eclipse.equinox.internal.ds.InstanceProcess.buildComponent(InstanceProcess.java:620) [org.eclipse.equinox.ds_1.4.400.v20160226-2036.jar:?]
        at org.eclipse.equinox.internal.ds.InstanceProcess.buildComponents(InstanceProcess.java:197) [org.eclipse.equinox.ds_1.4.400.v20160226-2036.jar:?]
        at org.eclipse.equinox.internal.ds.Resolver.getEligible(Resolver.java:343) [org.eclipse.equinox.ds_1.4.400.v20160226-2036.jar:?]
        at org.eclipse.equinox.internal.ds.SCRManager.serviceChanged(SCRManager.java:222) [org.eclipse.equinox.ds_1.4.400.v20160226-2036.jar:?]
        at org.eclipse.osgi.internal.serviceregistry.FilteredServiceListener.serviceChanged(FilteredServiceListener.java:113) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
        at org.eclipse.osgi.internal.framework.BundleContextImpl.dispatchEvent(BundleContextImpl.java:985) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
        at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:234) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
        at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:151) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
        at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEventPrivileged(ServiceRegistry.java:866) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
        at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEvent(ServiceRegistry.java:804) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
        at org.eclipse.osgi.internal.serviceregistry.ServiceRegistrationImpl.register(ServiceRegistrationImpl.java:130) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
        at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.registerService(ServiceRegistry.java:228) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
        at org.eclipse.osgi.internal.framework.BundleContextImpl.registerService(BundleContextImpl.java:525) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
        at org.eclipse.osgi.internal.framework.BundleContextImpl.registerService(BundleContextImpl.java:544) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
        at org.wso2.carbon.core.init.CarbonServerManager.initializeCarbon(CarbonServerManager.java:529) [org.wso2.carbon.core_4.5.1.jar:?]
        at org.wso2.carbon.core.init.CarbonServerManager.removePendingItem(CarbonServerManager.java:305) [org.wso2.carbon.core_4.5.1.jar:?]
        at org.wso2.carbon.core.init.PreAxis2ConfigItemListener.bundleChanged(PreAxis2ConfigItemListener.java:118) [org.wso2.carbon.core_4.5.1.jar:?]
        at org.eclipse.osgi.internal.framework.BundleContextImpl.dispatchEvent(BundleContextImpl.java:973) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
        at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:234) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
        at org.eclipse.osgi.framework.eventmgr.EventManager$EventThread.run(EventManager.java:345) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
Caused by: org.postgresql.util.PSQLException: ERROR: syntax error at end of input
  Position: 37
        at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2412) ~[postgresql-42.0.0.jar:42.0.0]
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2125) ~[postgresql-42.0.0.jar:42.0.0]
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:297) ~[postgresql-42.0.0.jar:42.0.0]
        at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:428) ~[postgresql-42.0.0.jar:42.0.0]
        at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:354) ~[postgresql-42.0.0.jar:42.0.0]
        at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:301) ~[postgresql-42.0.0.jar:42.0.0]
        at org.postgresql.jdbc.PgStatement.executeCachedSql(PgStatement.java:287) ~[postgresql-42.0.0.jar:42.0.0]
        at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:264) ~[postgresql-42.0.0.jar:42.0.0]
        at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:260) ~[postgresql-42.0.0.jar:42.0.0]
        at sun.reflect.GeneratedMethodAccessor64.invoke(Unknown Source) ~[?:?]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_202]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_202]
        at org.apache.tomcat.jdbc.pool.StatementFacade$StatementProxy.invoke(StatementFacade.java:114) ~[jdbc-pool_9.0.16.wso2v1.jar:?]
        at com.sun.proxy.$Proxy51.execute(Unknown Source) ~[?:?]
        at org.wso2.carbon.is.migration.service.SchemaMigrator.executeSQL(SchemaMigrator.java:273) ~[org.wso2.carbon.is.migration-1.0.79.jar:?]
        ... 32 more