### PR TITLE
Fix migration script issues related to MySQL

### DIFF
--- a/components/org.wso2.is.migration/migration-resources/5.8.0/dbscripts/step1/identity/mysql-cluster-5.7.sql
+++ b/components/org.wso2.is.migration/migration-resources/5.8.0/dbscripts/step1/identity/mysql-cluster-5.7.sql
@@ -12,6 +12,11 @@ ALTER TABLE IDN_OAUTH2_AUTHORIZATION_CODE
 
 DROP PROCEDURE IF EXISTS add_column_if_not_exists_with_default_val;
 
+SET @SAVE_sql_mode = @@sql_mode;
+SET SQL_MODE='ALLOW_INVALID_DATES';
+
+DELIMITER //
+
 CREATE PROCEDURE add_column_if_not_exists_with_default_val(tbl_name VARCHAR(64), clmn_name VARCHAR(64),
                                                            data_type VARCHAR(64), default_val VARCHAR(64))
 BEGIN
@@ -22,9 +27,11 @@ BEGIN
     PREPARE statement FROM @query; EXECUTE statement;
     SET @query = CONCAT('ALTER TABLE ', tbl_name, ' ALTER COLUMN ', clmn_name, ' drop default');
     PREPARE statement FROM @query; EXECUTE statement;
-END;
+END; //
 
-CALL add_column_if_not_exists_with_default_val('IDN_OAUTH2_AUTHORIZATION_CODE', 'IDP_ID', 'int', '-1');
+DELIMITER ;
+
+CALL add_column_if_not_exists_with_default_val('IDN_OAUTH2_AUTHORIZATION_CODE', 'IDP_ID', 'INT', '-1');
 
 CALL add_column_if_not_exists_with_default_val('IDN_OAUTH2_ACCESS_TOKEN', 'IDP_ID', 'INT', '-1');
 
@@ -38,6 +45,8 @@ ALTER TABLE IDN_OAUTH2_ACCESS_TOKEN
 ALTER TABLE IDN_OAUTH2_ACCESS_TOKEN
     ADD CONSTRAINT CON_APP_KEY UNIQUE (CONSUMER_KEY_ID, AUTHZ_USER, TENANT_ID, USER_DOMAIN, USER_TYPE, TOKEN_SCOPE_HASH,
                                        TOKEN_STATE, TOKEN_STATE_ID, IDP_ID);
+
+SET @@sql_mode = @SAVE_sql_mode;
 
 CREATE TABLE IF NOT EXISTS IDN_AUTH_USER
 (

--- a/components/org.wso2.is.migration/migration-resources/5.8.0/dbscripts/step1/identity/mysql.sql
+++ b/components/org.wso2.is.migration/migration-resources/5.8.0/dbscripts/step1/identity/mysql.sql
@@ -8,9 +8,28 @@ ALTER TABLE IDN_OAUTH2_AUTHORIZATION_CODE MODIFY CALLBACK_URL VARCHAR(2048);
 
 DROP PROCEDURE IF EXISTS add_column_if_not_exists_with_default_val;
 
-CREATE PROCEDURE add_column_if_not_exists_with_default_val(tbl_name VARCHAR(64), clmn_name VARCHAR(64), data_type VARCHAR(64), default_val VARCHAR(64)) BEGIN DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END; SET @query = CONCAT('ALTER TABLE ', tbl_name, ' ADD COLUMN ', clmn_name, ' ', data_type, ' NOT NULL default ', default_val); PREPARE statement FROM @query; EXECUTE statement; SET @query = CONCAT('ALTER TABLE ', tbl_name, ' ALTER COLUMN ', clmn_name, ' drop default'); PREPARE statement FROM @query; EXECUTE statement; END;
+SET @SAVE_sql_mode = @@sql_mode;
+SET SQL_MODE='ALLOW_INVALID_DATES';
 
-CALL add_column_if_not_exists_with_default_val('IDN_OAUTH2_AUTHORIZATION_CODE', 'IDP_ID', 'int', '-1');
+DELIMITER //
+
+CREATE PROCEDURE add_column_if_not_exists_with_default_val(tbl_name VARCHAR(64), clmn_name VARCHAR(64), data_type VARCHAR(64), default_val VARCHAR(64))
+BEGIN
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION
+
+        BEGIN
+        END;
+
+    SET @query = CONCAT('ALTER TABLE ', tbl_name, ' ADD COLUMN ', clmn_name, ' ', data_type, ' NOT NULL default ', default_val);
+    PREPARE statement FROM @query; EXECUTE statement;
+    SET @query = CONCAT('ALTER TABLE ', tbl_name, ' ALTER COLUMN ', clmn_name, ' drop default');
+    PREPARE statement FROM @query;
+    EXECUTE statement;
+END; //
+
+DELIMITER ;
+
+CALL add_column_if_not_exists_with_default_val('IDN_OAUTH2_AUTHORIZATION_CODE', 'IDP_ID', 'INT', '-1');
 
 CALL add_column_if_not_exists_with_default_val('IDN_OAUTH2_ACCESS_TOKEN', 'IDP_ID', 'INT', '-1');
 
@@ -21,6 +40,8 @@ DROP PROCEDURE IF EXISTS add_column_if_not_exists_with_default_val;
 ALTER TABLE IDN_OAUTH2_ACCESS_TOKEN DROP INDEX CON_APP_KEY;
 
 ALTER TABLE IDN_OAUTH2_ACCESS_TOKEN ADD CONSTRAINT CON_APP_KEY UNIQUE (CONSUMER_KEY_ID,AUTHZ_USER,TENANT_ID,USER_DOMAIN,USER_TYPE,TOKEN_SCOPE_HASH,TOKEN_STATE,TOKEN_STATE_ID,IDP_ID);
+
+SET @@sql_mode = @SAVE_sql_mode;
 
 CREATE TABLE IF NOT EXISTS IDN_AUTH_USER (
 	USER_ID VARCHAR(255) NOT NULL,

--- a/components/org.wso2.is.migration/migration-resources/5.8.0/dbscripts/step1/identity/mysql5.7.sql
+++ b/components/org.wso2.is.migration/migration-resources/5.8.0/dbscripts/step1/identity/mysql5.7.sql
@@ -8,9 +8,29 @@ ALTER TABLE IDN_OAUTH2_AUTHORIZATION_CODE MODIFY CALLBACK_URL VARCHAR(2048);
 
 DROP PROCEDURE IF EXISTS add_column_if_not_exists_with_default_val;
 
-CREATE PROCEDURE add_column_if_not_exists_with_default_val(tbl_name VARCHAR(64), clmn_name VARCHAR(64), data_type VARCHAR(64), default_val VARCHAR(64)) BEGIN DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END; SET @query = CONCAT('ALTER TABLE ', tbl_name, ' ADD COLUMN ', clmn_name, ' ', data_type, ' NOT NULL default ', default_val); PREPARE statement FROM @query; EXECUTE statement; SET @query = CONCAT('ALTER TABLE ', tbl_name, ' ALTER COLUMN ', clmn_name, ' drop default'); PREPARE statement FROM @query; EXECUTE statement; END;
+SET @SAVE_sql_mode = @@sql_mode;
+SET SQL_MODE='ALLOW_INVALID_DATES';
 
-CALL add_column_if_not_exists_with_default_val('IDN_OAUTH2_AUTHORIZATION_CODE', 'IDP_ID', 'int', '-1');
+DELIMITER //
+
+CREATE PROCEDURE add_column_if_not_exists_with_default_val(tbl_name VARCHAR(64), clmn_name VARCHAR(64), data_type VARCHAR(64), default_val VARCHAR(64))
+BEGIN
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION
+
+        BEGIN
+        END;
+
+    SET @query = CONCAT('ALTER TABLE ', tbl_name, ' ADD COLUMN ', clmn_name, ' ', data_type, ' NOT NULL default ', default_val);
+    PREPARE statement FROM @query;
+    EXECUTE statement;
+    SET @query = CONCAT('ALTER TABLE ', tbl_name, ' ALTER COLUMN ', clmn_name, ' drop default');
+    PREPARE statement FROM @query;
+    EXECUTE statement;
+END; //
+
+DELIMITER ;
+
+CALL add_column_if_not_exists_with_default_val('IDN_OAUTH2_AUTHORIZATION_CODE', 'IDP_ID', 'INT', '-1');
 
 CALL add_column_if_not_exists_with_default_val('IDN_OAUTH2_ACCESS_TOKEN', 'IDP_ID', 'INT', '-1');
 
@@ -21,6 +41,8 @@ DROP PROCEDURE IF EXISTS add_column_if_not_exists_with_default_val;
 ALTER TABLE IDN_OAUTH2_ACCESS_TOKEN DROP INDEX CON_APP_KEY;
 
 ALTER TABLE IDN_OAUTH2_ACCESS_TOKEN ADD CONSTRAINT CON_APP_KEY UNIQUE (CONSUMER_KEY_ID,AUTHZ_USER,TENANT_ID,USER_DOMAIN,USER_TYPE,TOKEN_SCOPE_HASH,TOKEN_STATE,TOKEN_STATE_ID,IDP_ID);
+
+SET @@sql_mode = @SAVE_sql_mode;
 
 CREATE TABLE IF NOT EXISTS IDN_AUTH_USER (
 	USER_ID VARCHAR(255) NOT NULL,

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v580/dao/OAuthDAO.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v580/dao/OAuthDAO.java
@@ -29,8 +29,8 @@ public class OAuthDAO {
     private static OAuthDAO instance = new OAuthDAO();
 
     private static final String UPDATE_TOKENS_OF_LOCAL_USERS = "UPDATE IDN_OAUTH2_ACCESS_TOKEN " +
-            "SET IDP_ID = (SELECT ID FROM IDP " +
-            "WHERE IDN_OAUTH2_ACCESS_TOKEN.TENANT_ID =  IDP.TENANT_ID AND IDP.NAME = \'LOCAL\') " +
+            "SET IDP_ID = IFNULL((SELECT ID FROM IDP " +
+            "WHERE IDN_OAUTH2_ACCESS_TOKEN.TENANT_ID =  IDP.TENANT_ID AND IDP.NAME = \'LOCAL\'),-1) " +
             "WHERE USER_DOMAIN != \'FEDERATED\'";
 
     private static final String UPDATE_AUTH_CODES_OF_LOCAL_USERS = "UPDATE IDN_OAUTH2_AUTHORIZATION_CODE " +


### PR DESCRIPTION
## Purpose
This PR will fix the following MySQL 5.7 syntax issues:
* IDP_ID column being populated with null values will stop proceeding with the migration script - fixed in reference with https://github.com/wso2/product-is/issues/7482 (issue: https://github.com/wso2-extensions/identity-migration-resources/issues/105)
* Call procedure syntax error + error on altering table with Timestamp column (issue: https://github.com/wso2-extensions/identity-migration-resources/issues/106)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
(For reference purposes) In addition, the following issues were also identified.
* https://github.com/wso2-extensions/identity-migration-resources/pull/95
* https://github.com/wso2-extensions/identity-migration-resources/pull/94
* https://github.com/wso2-extensions/identity-migration-resources/pull/91

## Test environment
> MySQL 5.7