### PR TITLE
FIx migration client for 5.10.0 to 5.11.0

### DIFF
--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v5110/migrator/EncryptionAdminFlowMigrator.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v5110/migrator/EncryptionAdminFlowMigrator.java
@@ -53,6 +53,7 @@ public class EncryptionAdminFlowMigrator extends Migrator {
         String symmetricKey = serverConfigService.getFirstProperty(SERVER_SYMMETRIC_KEY);
         if (SYMMETRIC_KEY_CRYPTO_PROVIDER.equals(internalCryptoProvider) && StringUtils.isNotBlank(symmetricKey)) {
             EncryptionUtil.setCurrentEncryptionAlgorithm(this);
+            EncryptionUtil.setMigratedEncryptionAlgorithm(this);
             migrateEventPublisherPassword();
             migrateTenantKeyStorePassword();
             migratepolicySubscriberPassword();

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v5110/migrator/EncryptionUserFlowMigrator.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v5110/migrator/EncryptionUserFlowMigrator.java
@@ -54,6 +54,7 @@ public class EncryptionUserFlowMigrator extends Migrator {
         String symmetricKey = serverConfigService.getFirstProperty(SERVER_SYMMETRIC_KEY);
         if (SYMMETRIC_KEY_CRYPTO_PROVIDER.equals(internalCryptoProvider) && StringUtils.isNotBlank(symmetricKey)) {
             EncryptionUtil.setCurrentEncryptionAlgorithm(this);
+            EncryptionUtil.setMigratedEncryptionAlgorithm(this);
             migrateTotpSecretKey();
             migrateOauthData();
             migrateUserPasswordInWorkFlow();

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/AuthzCodeDAO.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/AuthzCodeDAO.java
@@ -101,7 +101,7 @@ public class AuthzCodeDAO {
                         .prepareStatement(UPDATE_ENCRYPTED_AUTHORIZATION_CODE)) {
                     for (AuthzCodeInfo authzCodeInfo : updatedAuthzCodeList) {
                         preparedStatement.setString(1, authzCodeInfo.getAuthorizationCode());
-                        preparedStatement.setString(3, authzCodeInfo.getCodeId());
+                        preparedStatement.setString(2, authzCodeInfo.getCodeId());
                         preparedStatement.addBatch();
                     }
                     preparedStatement.executeBatch();

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/SQLConstants.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/SQLConstants.java
@@ -59,7 +59,7 @@ public class SQLConstants {
                     "OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";
 
     public static final String UPDATE_ENCRYPTED_ACCESS_TOKEN = "UPDATE IDN_OAUTH2_ACCESS_TOKEN SET " +
-            "ACCESS_TOKEN=?, REFRESH_TOKEN=?, WHERE TOKEN_ID=?";
+            "ACCESS_TOKEN=?, REFRESH_TOKEN=? WHERE TOKEN_ID=?";
 
     public static final String RETRIEVE_PAGINATED_AUTHORIZATION_CODES_MYSQL =
             "SELECT AUTHORIZATION_CODE, CODE_ID " +

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/TokenDAO.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/TokenDAO.java
@@ -104,7 +104,7 @@ public class TokenDAO {
                     for (OauthTokenInfo oauthTokenInfo : updatedOauthTokenList) {
                         preparedStatement.setString(1, oauthTokenInfo.getAccessToken());
                         preparedStatement.setString(2, oauthTokenInfo.getRefreshToken());
-                        preparedStatement.setString(5, oauthTokenInfo.getTokenId());
+                        preparedStatement.setString(3, oauthTokenInfo.getTokenId());
                         preparedStatement.addBatch();
                     }
                     preparedStatement.executeBatch();


### PR DESCRIPTION
## Purpose

1. Skip migrating values encrypted using new algorithm
       ex: newly added configurations files such as event publishers have values encrypted using symmetric encryption
2. Fix SQL issues in migration service
