### PR TITLE
Skip registry metadata properties during OIDC scope migration

### DIFF
--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v570/migrator/OIDCScopeDataMigrator.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v570/migrator/OIDCScopeDataMigrator.java
@@ -75,6 +75,7 @@ public class OIDCScopeDataMigrator extends Migrator {
     private static final String SCOPE_CLAIM_SEPERATOR = ",";
     private static final String ID = "id";
     private static final String CLAIM = "Claim";
+    private static final String REGISTRY_METADATA_PROPERTY_PREFIX = "registry.";
 
     private Map<String, String> scopeConfigFile = null;
 
@@ -192,7 +193,13 @@ public class OIDCScopeDataMigrator extends Migrator {
         if (oidcScopesResource != null) {
             for (Object scopeProperty : oidcScopesResource.getProperties().keySet()) {
                 String propertyKey = (String) scopeProperty;
-                propertiesToReturn.setProperty(propertyKey, oidcScopesResource.getProperty(propertyKey));
+                if (!StringUtils.startsWith(propertyKey, REGISTRY_METADATA_PROPERTY_PREFIX)) {
+                    propertiesToReturn.setProperty(propertyKey, oidcScopesResource.getProperty(propertyKey));
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Skipping registry resource metadata property: " + propertyKey + " from migration.");
+                    }
+                }
             }
         } else {
             log.error(Constant.MIGRATION_LOG + "OIDC scope resource cannot be found at " + SCOPE_RESOURCE_PATH


### PR DESCRIPTION
Avoids migrating registry properties with the "registry." prefix during OIDC scope migration.

Fixes https://github.com/wso2-extensions/identity-migration-resources/issues/138

This fix is to filter out the registry properties with "registry." prefix during OIDC scope migration. However, we need to investigate why these special properties are returned in the first place. So this is more of a quick fix.
