### PR TITLE
Fix backward compatibility issue of using commitTransaction and rollbackTransaction methods during 5.3 Migration

### DIFF
--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/dao/ClaimDAO.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/dao/ClaimDAO.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.is.migration.service.v530.SQLConstants;
 import org.wso2.carbon.is.migration.service.v530.bean.Claim;
 import org.wso2.carbon.is.migration.service.v530.bean.MappedAttribute;
+import org.wso2.carbon.is.migration.service.v530.util.JDBCPersistenceUtil;
 import org.wso2.carbon.utils.DBUtils;
 
 import java.sql.Connection;
@@ -78,10 +79,9 @@ public class ClaimDAO {
             prepStmt.setString(1, claimDialectURI);
             prepStmt.setInt(2, tenantId);
             prepStmt.executeUpdate();
-            IdentityDatabaseUtil.commitTransaction(connection);
-
+            JDBCPersistenceUtil.commitTransaction(connection);
         } catch (SQLException e) {
-            IdentityDatabaseUtil.rollbackTransaction(connection);
+            JDBCPersistenceUtil.rollbackTransaction(connection);
             throw new MigrationClientException("Error while adding claim dialect " + claimDialectURI, e);
         } finally {
             IdentityDatabaseUtil.closeStatement(prepStmt);
@@ -194,9 +194,9 @@ public class ClaimDAO {
             }
 
             // End transaction
-            IdentityDatabaseUtil.commitTransaction(connection);
+            JDBCPersistenceUtil.commitTransaction(connection);
         } catch (SQLException e) {
-            IdentityDatabaseUtil.rollbackTransaction(connection);
+            JDBCPersistenceUtil.rollbackTransaction(connection);
             throw new MigrationClientException("Error while adding local claim " + localClaimURI, e);
         } finally {
             IdentityDatabaseUtil.closeConnection(connection);
@@ -537,9 +537,9 @@ public class ClaimDAO {
                 }
             }
             // End transaction
-            IdentityDatabaseUtil.commitTransaction(connection);
+            JDBCPersistenceUtil.commitTransaction(connection);
         } catch (SQLException e) {
-            IdentityDatabaseUtil.rollbackTransaction(connection);
+            JDBCPersistenceUtil.rollbackTransaction(connection);
             throw new MigrationClientException("Error while adding external claim " + externalClaimURI + " to " +
                     "dialect " + externalClaimDialectURI, e);
         } finally {
@@ -598,3 +598,4 @@ public class ClaimDAO {
     }
 
 }
+

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/dao/IdpMetaDataDAO.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/dao/IdpMetaDataDAO.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import org.wso2.carbon.identity.core.migrate.MigrationClientException;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.is.migration.service.v530.SQLConstants;
+import org.wso2.carbon.is.migration.service.v530.util.JDBCPersistenceUtil;
 import org.wso2.carbon.utils.DBUtils;
 
 import java.sql.Connection;
@@ -126,9 +127,9 @@ public class IdpMetaDataDAO {
                 prepStmt.setInt(5, idpMetaData.getTenantId());
                 prepStmt.executeUpdate();
             }
-            IdentityDatabaseUtil.commitTransaction(connection);
+            JDBCPersistenceUtil.commitTransaction(connection);
         } catch (SQLException e) {
-            IdentityDatabaseUtil.rollbackTransaction(connection);
+            JDBCPersistenceUtil.rollbackTransaction(connection);
             throw new MigrationClientException("Error while inserting default resident idp property values.", e);
         } finally {
             IdentityDatabaseUtil.closeStatement(prepStmt);

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/util/JDBCPersistenceUtil.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/util/JDBCPersistenceUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.is.migration.service.v530.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class JDBCPersistenceUtil {
+
+    private static final Logger log = LoggerFactory.getLogger(JDBCPersistenceUtil.class);
+
+    /**
+     * Revoke the transaction when catch then sql transaction errors.
+     *
+     * @param dbConnection database connection.
+     */
+    public static void rollbackTransaction(Connection dbConnection) {
+
+        try {
+            if (dbConnection != null) {
+                dbConnection.rollback();
+            }
+        } catch (SQLException e1) {
+            log.error("An error occurred while rolling back transactions. ", e1);
+        }
+    }
+
+    /**
+     * Commit the transaction.
+     *
+     * @param dbConnection database connection.
+     */
+    public static void commitTransaction(Connection dbConnection) {
+
+        try {
+            if (dbConnection != null) {
+                dbConnection.commit();
+            }
+        } catch (SQLException e1) {
+            log.error("An error occurred while commit transactions. ", e1);
+        }
+    }
+}
+

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/util/JDBCPersistenceUtil.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/util/JDBCPersistenceUtil.java
@@ -54,8 +54,8 @@ public class JDBCPersistenceUtil {
             if (dbConnection != null) {
                 dbConnection.commit();
             }
-        } catch (SQLException e1) {
-            log.error("An error occurred while commit transactions. ", e1);
+        } catch (SQLException e) {
+            log.error("An error occurred while commit transactions.", e);
         }
     }
 }

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/util/JDBCPersistenceUtil.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/util/JDBCPersistenceUtil.java
@@ -38,8 +38,8 @@ public class JDBCPersistenceUtil {
             if (dbConnection != null) {
                 dbConnection.rollback();
             }
-        } catch (SQLException e1) {
-            log.error("An error occurred while rolling back transactions. ", e1);
+        } catch (SQLException e) {
+            log.error("An error occurred while rolling back transactions.", e);
         }
     }
 
@@ -59,4 +59,3 @@ public class JDBCPersistenceUtil {
         }
     }
 }
-

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/util/JDBCPersistenceUtil.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/util/JDBCPersistenceUtil.java
@@ -23,6 +23,9 @@ import org.slf4j.LoggerFactory;
 import java.sql.Connection;
 import java.sql.SQLException;
 
+/**
+ * This class handles the common database util operations needed for v530 migration.
+ */
 public class JDBCPersistenceUtil {
 
     private static final Logger log = LoggerFactory.getLogger(JDBCPersistenceUtil.class);


### PR DESCRIPTION
## Purpose
Fix NoSuchMethodError: org.wso2.carbon.identity.core.util.IdentityDatabaseUtil.commitTransaction  https://github.com/wso2/product-apim/issues/9049

## Goals
Add commitTransaction and rollbackTransaction JDBC util methods.

## Tested
JDK 1.8 
Ubuntu 19.04
Oracle 12c with API-M 2.0 to 2.6
Postgres 9.6 with API-M 2.0 to 2.6
