### PR TITLE
Enable Symmetric Key Encryption Migration parameters by default

### DIFF
--- a/components/org.wso2.is.migration/migration-resources/migration-config.yaml
+++ b/components/org.wso2.is.migration/migration-resources/migration-config.yaml
@@ -381,9 +381,17 @@ versions:
    -
      name: "EncryptionAdminFlowMigrator"
      order: 1
+     parameters:
+       currentEncryptionAlgorithm: "RSA/ECB/OAEPwithSHA1andMGF1Padding"
+       migratedEncryptionAlgorithm: "AES/GCM/NoPadding"
+       schema: "identity"
    -
      name: "EncryptionUserFlowMigrator"
      order: 2
+     parameters:
+       currentEncryptionAlgorithm: "RSA/ECB/OAEPwithSHA1andMGF1Padding"
+       migratedEncryptionAlgorithm: "AES/GCM/NoPadding"
+       schema: "identity"
    -
      name: "SchemaMigrator"
      order: 3


### PR DESCRIPTION
## Purpose
> Enable Symmetric Key Encryption Migration parameters by default. 
> If the currentEncryptionAlgorithm is different from what we have provided by default that should be changed and instructions for that should be provided in migration doc
