### PR TITLE
Remove userstore from username when retrieving userid

### DIFF
--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v5100/migrator/UserIDMigrator.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v5100/migrator/UserIDMigrator.java
@@ -18,6 +18,7 @@ package org.wso2.carbon.is.migration.service.v5100.migrator;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.core.migrate.MigrationClientException;
 import org.wso2.carbon.is.migration.internal.ISMigrationServiceDataHolder;
 import org.wso2.carbon.is.migration.service.Migrator;
@@ -199,6 +200,7 @@ public class UserIDMigrator extends Migrator {
 
                         // Iterate for each user.
                         for (String username : userList) {
+                            username = UserCoreUtil.removeDomainFromName(username);
                             if (log.isDebugEnabled()) {
                                 log.debug("Migrating user {}, counter index {}", username, userCounter);
                             }
@@ -226,7 +228,8 @@ public class UserIDMigrator extends Migrator {
                                     // In this scenario, we have generated the UUID using SQL. So we have to get it
                                     // and add it as the user id claim.
                                     String userId = getUserIDClaimFromDB(username, tenantId);
-                                    updateUserIDClaim(username, userId, abstractUserStoreManager, forceUpdateUserId);
+                                    updateUserIDClaim(username, userId, abstractUserStoreManager,
+                                            forceUpdateUserId);
                                 }
                             }
 


### PR DESCRIPTION
When running the UserIDMigrator, there is a Null Pointer exception when updating the user-id of the users. This is happening the user-id is not retrieved when the userstore domain name is appended in the username. In that case, user-id is returned as null.

```
TID: [-1234] [] [2020-10-07 14:12:08,898] ERROR {org.wso2.carbon.is.migration.MigrationClientImpl} - Migration process was stopped. java.lang.NullPointerException
	at java.util.HashMap.merge(HashMap.java:1225)
	at java.util.stream.Collectors.lambda$toMap$58(Collectors.java:1320)
	at java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
	at java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1696)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
	at org.wso2.carbon.user.core.jdbc.JDBCUserStoreManager.filterNewlyAddedProperties(JDBCUserStoreManager.java:2273)
	at org.wso2.carbon.user.core.jdbc.JDBCUserStoreManager.doSetUserAttributes(JDBCUserStoreManager.java:2243)
	at org.wso2.carbon.user.core.common.AbstractUserStoreManager.doSetUserClaimValues(AbstractUserStoreManager.java:670)
	at org.wso2.carbon.user.core.jdbc.JDBCUserStoreManager.doSetUserClaimValues(JDBCUserStoreManager.java:2228)
	at org.wso2.carbon.is.migration.service.v5100.migrator.UserIDMigrator.updateUserIDClaim(UserIDMigrator.java:336)
	at org.wso2.carbon.is.migration.service.v5100.migrator.UserIDMigrator.migrate(UserIDMigrator.java:229)
	at org.wso2.carbon.is.migration.VersionMigration.migrate(VersionMigration.java:52)
	at org.wso2.carbon.is.migration.MigrationClientImpl.execute(MigrationClientImpl.java:85)
	at org.wso2.carbon.identity.core.internal.IdentityCoreServiceComponent.activate(IdentityCoreServiceComponent.java:147)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
```

This PR is fixing this issue by removing the userstore domain from the username before updating the user-id of the user.