### PR TITLE
Handle tenant keystore password migration

### DIFF
--- a/components/org.wso2.is.migration/migration-resources/migration-config.yaml
+++ b/components/org.wso2.is.migration/migration-resources/migration-config.yaml
@@ -208,6 +208,9 @@ versions:
     order: 9
     parameters:
       schema: "identity"
+      currentEncryptionAlgorithm: "RSA"
+      migratedEncryptionAlgorithm: "RSA/ECB/OAEPwithSHA1andMGF1Padding"
+      transformToSymmetric: "false"
    -
     name: "SecurityPolicyPasswordMigrator"
     order: 10

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v550/migrator/KeyStorePasswordMigrator.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v550/migrator/KeyStorePasswordMigrator.java
@@ -21,8 +21,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.identity.core.migrate.MigrationClientException;
 import org.wso2.carbon.is.migration.service.Migrator;
-import org.wso2.carbon.is.migration.service.v550.RegistryDataManager;
 import org.wso2.carbon.is.migration.util.Constant;
+import org.wso2.carbon.is.migration.util.EncryptionUtil;
 
 /**
  * KeyStorePasswordMigrator.
@@ -35,6 +35,8 @@ public class KeyStorePasswordMigrator extends Migrator {
     public void migrate() throws MigrationClientException {
 
         try {
+            EncryptionUtil.setCurrentEncryptionAlgorithm(this);
+            EncryptionUtil.setMigratedEncryptionAlgorithm(this);
             migrateKeystorePasswords();
         } catch (Exception e) {
             String errorMsg = "Error while migrating key store passwords";
@@ -54,7 +56,14 @@ public class KeyStorePasswordMigrator extends Migrator {
     private void migrateKeystorePasswords() throws Exception {
 
         log.info(Constant.MIGRATION_LOG + "Migration starting on Key Stores");
-        RegistryDataManager registryDataManager = RegistryDataManager.getInstance();
-        registryDataManager.migrateKeyStorePassword(isIgnoreForInactiveTenants(), isContinueOnError());
+        if (Boolean.parseBoolean(this.getMigratorConfig().getParameterValue("transformToSymmetric"))) {
+            org.wso2.carbon.is.migration.util.RegistryDataManager registryDataManager = org.wso2.carbon.is.migration.
+                    util.RegistryDataManager.getInstance();
+            registryDataManager.migrateKeyStorePassword(isIgnoreForInactiveTenants(), isContinueOnError());
+        } else {
+            org.wso2.carbon.is.migration.service.v550.RegistryDataManager registryDataManager = org.wso2.carbon.is.
+                    migration.service.v550.RegistryDataManager.getInstance();
+            registryDataManager.migrateKeyStorePassword(isIgnoreForInactiveTenants(), isContinueOnError());
+        }
     }
 }


### PR DESCRIPTION
## Purpose
 org.wso2.carbon.is.migration.service.v550.RegistryDataManager Cannot handle the keystore migration when we configured symmetric encrption provider (by default in 5.11) 

So for 5.11 migration we need to configure transformToSymmetric as true before the migration process. 

For all other migrations below that we should make that property false. 

In that case org.wso2.carbon.is.migration.service.v550.RegistryDataManager will be used for decryption process. 


