### PR TITLE
added userid migration scripts.

### DIFF
--- a/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/db2.sql
+++ b/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/db2.sql
@@ -1,0 +1,108 @@
+CREATE OR REPLACE PROCEDURE USERID_MIGRATION_SP ()
+     DYNAMIC RESULT SETS 0
+     MODIFIES SQL DATA
+     LANGUAGE SQL
+	BEGIN
+	    DECLARE chunkSize INT;
+	    DECLARE threshold INT;
+	    DECLARE totalMigrated ;
+	    DECLARE chunkCount INT;
+	    DECLARE query varchar(200);
+	    DECLARE offset INT;
+	    DECLARE forceUpdate BOOLEAN;
+	    DECLARE scimEnable BOOLEAN;
+	   
+	    SET chunkSize = 1000;
+	    SET threshold = 9999999;
+	    SET totalMigrated = 0;
+	    SET chunkCount = 1;
+	    SET offset = 0;
+	    SET forceUpdate =  FALSE;
+	    SET scimEnable = TRUE; 
+   
+	
+      	CREATE TABLE TMP_UM_USER_UUID AS (SELECT UM_USER_NAME,UM_ID, UM_USER_ID FROM UM_USER) WITH DATA;
+     
+        WHILE (chunkCount!=0 and totalMigrated < threshold ) DO
+            
+          SET offset=totalMigrated+chunkSize;
+                
+          CREATE TABLE TMP_UM_USER_UUID_CHUNK LIKE TMP_UM_USER_UUID;
+          
+       	  INSERT INTO TMP_UM_USER_UUID_CHUNK SELECT * FROM TMP_UM_USER_UUID LIMIT offset, chunkSize;                            
+        
+          ALTER TABLE TMP_UM_USER_UUID_CHUNK
+          ADD CONSTRAINT pk PRIMARY KEY (UM_ID);
+       	    
+          SET chunkCount = (SELECT COUNT FROM TMP_UM_USER_UUID_CHUNK);
+           
+         -- If it is force update then update the existing scim id with newly generated um_user_id in um_user table
+          IF forceUpdate THEN
+
+            UPDATE UM_USER_ATTRIBUTE as t1
+            SET UM_ATTR_VALUE = t2.UM_USER_ID
+			FROM TMP_UM_USER_UUID_CHUNK AS t2 
+	        WHERE t1.UM_USER_ID = t2.UM_ID
+	        and t1.UM_ATTR_VALUE != t2.UM_USER_ID
+	        and t1.UM_ATTR_NAME='scimId';
+	       
+		  END IF;
+		  -- insert scim id claim for the users who doesnt have one
+          INSERT INTO UM_USER_ATTRIBUTE (UM_USER_ID, UM_ATTR_NAME, UM_ATTR_VALUE, UM_PROFILE_ID, UM_TENANT_ID)
+          	SELECT t1.UM_ID, 'scimId', t1.UM_USER_ID, 'default', -1234
+            FROM TMP_UM_USER_UUID_CHUNK t1
+            LEFT JOIN 
+            (SELECT DISTINCT(t8.UM_ID), t8.UM_USER_NAME
+            	FROM TMP_UM_USER_UUID_CHUNK t8
+             	LEFT JOIN UM_USER_ATTRIBUTE t9
+             	ON t8.UM_ID = t9.UM_USER_ID
+                WHERE t9.UM_ATTR_NAME='scimId') t2
+                ON t1.UM_ID = t2.UM_ID
+                WHERE t2.UM_ID IS NULL;
+               
+             -- insert uid claim for the users who doesnt have one
+            INSERT INTO UM_USER_ATTRIBUTE (UM_USER_ID, UM_ATTR_NAME, UM_ATTR_VALUE, UM_PROFILE_ID, UM_TENANT_ID)
+                SELECT t1.UM_ID, 'uid', t1.UM_USER_NAME, 'default', -1234
+                FROM TMP_UM_USER_UUID_CHUNK t1
+                LEFT JOIN 
+                    (SELECT DISTINCT(t8.UM_ID), t8.UM_USER_NAME
+                    FROM TMP_UM_USER_UUID_CHUNK t8
+                    LEFT JOIN UM_USER_ATTRIBUTE t9
+                    ON t8.UM_ID = t9.UM_USER_ID
+                    WHERE t9.UM_ATTR_NAME='uid') t2
+                ON t1.UM_ID = t2.UM_ID
+                WHERE t2.UM_ID IS NULL;
+       
+            -- if scim enable and not a force update then generated um_user_id wll be replaced with user's existing scim claim value
+            IF (NOT forceUpdate AND scimEnable) THEN
+                     
+               CREATE TABLE TMP_UM_USER_SCIM AS
+				 (SELECT t1.UM_ID, t1.UM_USER_ID,t2.UM_ATTR_VALUE FROM TMP_UM_USER_UUID_CHUNK t1 
+			  	  INNER JOIN UM_USER_ATTRIBUTE t2 ON t1.UM_ID = t2.UM_USER_ID WHERE t2.UM_ATTR_NAME='scimId');
+		    
+			  ALTER TABLE TMP_UM_USER_SCIM
+			  ADD PRIMARY KEY (UM_ID),
+              ADD UNIQUE(UM_ATTR_VALUE);
+
+              UPDATE UM_USER AS t1
+              SET UM_USER_ID = t2.UM_ATTR_VALUE;
+              FROM TMP_UM_USER_SCIM as t2
+              where t1.UM_ID = t2.UM_ID
+              
+			  DROP TABLE TMP_UM_USER_SCIM;
+
+            END IF;
+            
+           SET totalMigrated = totalMigrated + chunkCount;
+           DROP TABLE TMP_UM_USER_UUID_CHUNK;
+
+ 		END WHILE;
+ 		
+        DROP TABLE TMP_UM_USER_UUID;
+      
+ 		COMMIT;
+		
+END;
+
+
+

--- a/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/mssql.sql
+++ b/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/mssql.sql
@@ -1,0 +1,114 @@
+DROP PROCEDURE IF EXISTS USERID_MIGRATION_SP;
+
+CREATE PROCEDURE USERID_MIGRATION_SP
+AS
+BEGIN
+ 
+    DECLARE @chunkSize INT
+    DECLARE @threshold INT
+    DECLARE @totalMigrated INT
+    DECLARE @chunkCount INT
+    DECLARE @query varchar(200)
+    DECLARE @offset INT
+    DECLARE @forceUpdate bit
+    DECLARE @scimEnable bit 
+   
+    SET @chunkSize = 1000
+    SET @threshold = 9999999
+    SET @totalMigrated = 0
+    SET @chunkCount = 1
+    SET @offset = 0
+    SET @forceUpdate =  0
+    SET @scimEnable =  1
+    
+	BEGIN
+		
+		CREATE TABLE TMP_UM_USER_UUID (
+        UM_USER_NAME varchar(255) NOT NULL UNIQUE,
+        UM_ID int PRIMARY KEY,
+        UUID varchar(36) NOT NULL
+        )
+        INSERT INTO TMP_UM_USER_UUID SELECT UM_USER_NAME, UM_ID, UM_USER_ID FROM UM_USER
+        
+        WHILE (@chunkCount!=0 and @totalMigrated < @threshold ) BEGIN
+            
+            SET @offset=@totalMigrated+@chunkSize    
+            
+            Select * into TMP_UM_USER_UUID_CHUNK  from  TMP_UM_USER_UUID ORDER BY UM_ID OFFSET @totalMigrated ROWS FETCH NEXT @chunkSize ROWS ONLY
+            
+            ALTER TABLE TMP_UM_USER_UUID_CHUNK
+            ADD CONSTRAINT pk PRIMARY KEY (UM_ID)
+       	    
+		    SET @chunkCount = (select COUNT(*) from TMP_UM_USER_UUID_CHUNK)
+		    
+            -- If it is force update then update the existing scim id with newly generated um_user_id in um_user table
+            IF @forceUpdate = 1
+                BEGIN
+                    UPDATE  t1 
+                    SET t1.UM_ATTR_VALUE = t2.UUID
+                    FROM UM_USER_ATTRIBUTE AS t1
+                    INNER JOIN TMP_UM_USER_UUID_CHUNK AS t2 
+                    ON t1.UM_USER_ID = t2.UM_ID
+                    WHERE t1.UM_ATTR_VALUE != t2.UUID
+                    and t1.UM_ATTR_NAME='scimId'
+                END 
+		  -- Insert scim id claim for the users who doesnt have one
+			INSERT INTO UM_USER_ATTRIBUTE (UM_USER_ID, UM_ATTR_NAME, UM_ATTR_VALUE, UM_PROFILE_ID, UM_TENANT_ID)
+                SELECT t1.UM_ID, 'scimId', t1.UUID, 'default', -1234
+                FROM TMP_UM_USER_UUID_CHUNK t1
+                LEFT JOIN 
+                    (SELECT DISTINCT(t8.UM_ID), t8.UM_USER_NAME
+                    FROM TMP_UM_USER_UUID_CHUNK t8
+                    LEFT JOIN UM_USER_ATTRIBUTE t9
+                    ON t8.UM_ID = t9.UM_USER_ID
+                    WHERE t9.UM_ATTR_NAME='scimId') t2
+                ON t1.UM_ID = t2.UM_ID
+                WHERE t2.UM_ID IS NULL
+            
+            -- Insert uid claim for the users who doesnt have one
+            INSERT INTO UM_USER_ATTRIBUTE (UM_USER_ID, UM_ATTR_NAME, UM_ATTR_VALUE, UM_PROFILE_ID, UM_TENANT_ID)
+                SELECT t1.UM_ID, 'uid', t1.UM_USER_NAME, 'default', -1234
+                FROM TMP_UM_USER_UUID_CHUNK t1
+                LEFT JOIN 
+                    (SELECT DISTINCT(t8.UM_ID), t8.UM_USER_NAME
+                    FROM TMP_UM_USER_UUID_CHUNK t8
+                    LEFT JOIN UM_USER_ATTRIBUTE t9
+                    ON t8.UM_ID = t9.UM_USER_ID
+                    WHERE t9.UM_ATTR_NAME='uid') t2
+                ON t1.UM_ID = t2.UM_ID
+                WHERE t2.UM_ID IS NULL
+            
+            -- If scim enable and not a force update then generated um_user_id wll be replaced with user's existing scim claim value 
+            IF (@forceUpdate = 0 AND @scimEnable = 1)
+                BEGIN 
+                    Select t1.UM_ID, t1.UUID,t2.UM_ATTR_VALUE into TMP_UM_USER_SCIM 
+                    FROM TMP_UM_USER_UUID_CHUNK as t1 
+                    INNER JOIN UM_USER_ATTRIBUTE as t2
+                    ON t1.UM_ID = t2.UM_USER_ID 
+                    WHERE t2.UM_ATTR_NAME='scimId'
+			 
+                    ALTER TABLE TMP_UM_USER_SCIM
+                    ADD CONSTRAINT pky PRIMARY KEY (UM_ID)
+                    
+                    ALTER TABLE TMP_UM_USER_SCIM
+                    ADD CONSTRAINT unk UNIQUE (UM_ATTR_VALUE)   
+
+                    UPDATE t1
+                    SET t1.UM_USER_ID = t2.UM_ATTR_VALUE
+                    FROM UM_USER AS t1
+                    INNER JOIN TMP_UM_USER_SCIM AS t2
+                    ON t1.UM_ID = t2.UM_ID
+              
+		            DROP TABLE TMP_UM_USER_SCIM
+
+                END 
+
+            SET @totalMigrated = @totalMigrated + @chunkCount
+            DROP TABLE TMP_UM_USER_UUID_CHUNK
+            
+ 		END
+        DROP TABLE TMP_UM_USER_UUID	
+	END
+END
+GO
+

--- a/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/mysql.sql
+++ b/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/mysql.sql
@@ -1,0 +1,100 @@
+DROP PROCEDURE IF EXISTS USERID_MIGRATION_SP;
+
+DELIMITER //
+
+CREATE PROCEDURE USERID_MIGRATION_SP()
+BEGIN 
+    DECLARE chunkSize INT DEFAULT 1000;
+    DECLARE threshold INT DEFAULT 9999999;
+    DECLARE totalMigrated INT DEFAULT 0;
+    DECLARE chunkCount INT DEFAULT 1;
+    DECLARE query varchar(200);
+    DECLARE offset INT DEFAULT 0;
+    DECLARE forceUpdate BOOLEAN  DEFAULT  FALSE;
+    DECLARE scimEnable BOOLEAN  DEFAULT  TRUE;
+    
+	BEGIN
+      	CREATE TABLE TMP_UM_USER_UUID AS (SELECT UM_USER_NAME,UM_ID, UM_USER_ID FROM UM_USER);
+     
+        WHILE (chunkCount!=0 and totalMigrated < threshold ) DO
+            
+            SET offset=totalMigrated+chunkSize;
+                
+            CREATE TABLE TMP_UM_USER_UUID_CHUNK SELECT * FROM TMP_UM_USER_UUID LIMIT totalMigrated, chunkSize;
+                                    
+            ALTER TABLE TMP_UM_USER_UUID_CHUNK
+            ADD CONSTRAINT pk PRIMARY KEY (UM_ID);
+       	    
+            SELECT COUNT(*) FROM TMP_UM_USER_UUID_CHUNK INTO chunkCount;
+            
+            -- If it is force update then update the existing scim id with newly generated um_user_id in um_user table
+            IF forceUpdate THEN
+
+                UPDATE UM_USER_ATTRIBUTE t1
+                INNER JOIN TMP_UM_USER_UUID_CHUNK t2 
+                ON t1.UM_USER_ID = t2.UM_ID
+                SET t1.UM_ATTR_VALUE = t2.UM_USER_ID
+                WHERE t1.UM_ATTR_VALUE != t2.UM_USER_ID
+                and t1.UM_ATTR_NAME='scimId';
+			END IF;
+             -- insert scimid claim for the users who doesnt have one
+            INSERT INTO UM_USER_ATTRIBUTE (UM_USER_ID, UM_ATTR_NAME, UM_ATTR_VALUE, UM_PROFILE_ID, UM_TENANT_ID)
+            SELECT t1.UM_ID, 'scimId', t1.UM_USER_ID, 'default', -1234
+                FROM TMP_UM_USER_UUID_CHUNK t1
+                LEFT JOIN 
+                    (SELECT DISTINCT(t8.UM_ID), t8.UM_USER_NAME
+                    FROM TMP_UM_USER_UUID_CHUNK t8
+                    LEFT JOIN UM_USER_ATTRIBUTE t9
+                    ON t8.UM_ID = t9.UM_USER_ID
+                    WHERE t9.UM_ATTR_NAME='scimId') t2
+                ON t1.UM_ID = t2.UM_ID
+                WHERE t2.UM_ID IS NULL;
+           
+		  -- insert scim id claim for the users who doesnt have one
+            INSERT INTO UM_USER_ATTRIBUTE (UM_USER_ID, UM_ATTR_NAME, UM_ATTR_VALUE, UM_PROFILE_ID, UM_TENANT_ID)
+            SELECT t1.UM_ID, 'uid', t1.UM_USER_NAME, 'default', -1234
+                FROM TMP_UM_USER_UUID_CHUNK t1
+                LEFT JOIN 
+                    (SELECT DISTINCT(t8.UM_ID), t8.UM_USER_NAME
+                    FROM TMP_UM_USER_UUID_CHUNK t8
+                    LEFT JOIN UM_USER_ATTRIBUTE t9
+                    ON t8.UM_ID = t9.UM_USER_ID
+                    WHERE t9.UM_ATTR_NAME='uid') t2
+                ON t1.UM_ID = t2.UM_ID
+                WHERE t2.UM_ID IS NULL;
+       
+            -- if scim enable and not a force update then generated um_user_id wll be replaced with user's existing scim claim value
+            IF (NOT forceUpdate AND scimEnable) THEN
+                     
+                CREATE TABLE TMP_UM_USER_SCIM AS
+			    (SELECT t1.UM_ID, t1.UM_USER_ID,t2.UM_ATTR_VALUE FROM TMP_UM_USER_UUID_CHUNK t1 
+			    INNER JOIN UM_USER_ATTRIBUTE t2 ON t1.UM_ID = t2.UM_USER_ID WHERE t2.UM_ATTR_NAME='scimId');
+
+        		ALTER TABLE TMP_UM_USER_SCIM
+		    	ADD PRIMARY KEY (UM_ID),
+                ADD UNIQUE(UM_ATTR_VALUE);
+
+                UPDATE UM_USER t1
+                INNER JOIN TMP_UM_USER_SCIM t2
+                ON t1.UM_ID = t2.UM_ID
+                SET t1.UM_USER_ID = t2.UM_ATTR_VALUE;
+                
+                DROP TABLE TMP_UM_USER_SCIM;
+
+            END IF;
+
+            SET totalMigrated = totalMigrated + chunkCount;
+            DROP TABLE TMP_UM_USER_UUID_CHUNK;
+
+ 		END WHILE;
+ 		
+        DROP TABLE TMP_UM_USER_UUID;
+      		
+	END;
+
+END;
+//
+
+DELIMITER ;
+
+

--- a/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/oracle.sql
+++ b/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/oracle.sql
@@ -1,0 +1,121 @@
+CREATE OR REPLACE PROCEDURE USERID_MIGRATION_SP
+IS
+BEGIN 
+DECLARE 
+    chunkSize INT:=1000;
+    threshold INT:=9999999;
+    totalMigrated INT:=0;
+    chunkCount INT:=1;
+    query varchar(200);
+    offset INT:=0;
+    forceUpdate BOOLEAN := FALSE;
+    scimEnable BOOLEAN := TRUE;
+    
+	BEGIN
+		DBMS_OUTPUT.ENABLE;
+      		query:='CREATE TABLE TMP_UM_USER_UUID AS (SELECT UM_USER_NAME,UM_ID, UM_USER_ID FROM UM_USER)';
+   		EXECUTE IMMEDIATE query;
+        COMMIT;
+     
+        WHILE (chunkCount!=0 and totalMigrated < threshold ) LOOP
+            
+            offset:=totalMigrated+chunkSize;
+                
+            EXECUTE IMMEDIATE 'CREATE TABLE TMP_UM_USER_UUID_CHUNK AS (
+                SELECT UM_USER_NAME,UM_ID, UM_USER_ID
+                    FROM   (SELECT UM_USER_NAME,UM_ID, UM_USER_ID, rownum AS rnum
+                            FROM   (SELECT UM_USER_NAME,UM_ID, UM_USER_ID
+                                    FROM   TMP_UM_USER_UUID
+                                    ORDER BY UM_ID)
+                            WHERE rownum <= '||offset||')
+                    WHERE  rnum > '||totalMigrated||')';
+            COMMIT;
+        
+            EXECUTE IMMEDIATE'ALTER TABLE TMP_UM_USER_UUID_CHUNK
+                                ADD CONSTRAINT pk PRIMARY KEY (UM_ID)';
+            COMMIT;
+       	    
+               dbms_output.put_line('Migrated count: ' || totalMigrated || 'chunk size: ' || chunkSize );
+
+            EXECUTE IMMEDIATE'  SELECT COUNT(*) FROM TMP_UM_USER_UUID_CHUNK' INTO chunkCount;
+            COMMIT;
+           
+           IF forceUpdate THEN
+       	   DBMS_OUTPUT.PUT_LINE('SCIM FOCE UPDATE update migration....');
+    --    UPDATE UM_USER_ATTRIBUTE SET UM_ATTR_VALUE=? WHERE UM_USER_ID=@userId AND UM_ATTR_NAME='scimId'
+--    enable IF focrce UPDATE IS TRUE only
+            EXECUTE IMMEDIATE 'UPDATE 
+                (SELECT t1.UM_ATTR_VALUE as UM_ATTR_VALUE, t2.UM_USER_NAME as UM_USER_NAME, t2.UM_USER_ID
+                FROM UM_USER_ATTRIBUTE t1
+                INNER JOIN TMP_UM_USER_UUID_CHUNK t2 
+                ON t1.UM_USER_ID = t2.UM_ID
+                WHERE t1.UM_ATTR_VALUE != t2.UM_USER_ID and t1.UM_ATTR_NAME=''scimId''
+                ) t
+                SET t.UM_ATTR_VALUE = t.UM_USER_ID';
+            COMMIT;
+			END IF;
+	-- Insert scimId claim for users who didn't have a scimId    
+            EXECUTE IMMEDIATE 'INSERT INTO UM_USER_ATTRIBUTE (UM_USER_ID, UM_ATTR_NAME, UM_ATTR_VALUE, UM_PROFILE_ID, UM_TENANT_ID)
+                SELECT t1.UM_ID, ''scimId'', t1.UM_USER_ID, ''default'', -1234
+                FROM TMP_UM_USER_UUID_CHUNK t1
+                LEFT JOIN 
+                    (SELECT DISTINCT(t8.UM_ID), t8.UM_USER_NAME
+                    FROM TMP_UM_USER_UUID_CHUNK t8
+                    LEFT JOIN UM_USER_ATTRIBUTE t9
+                    ON t8.UM_ID = t9.UM_USER_ID
+                    WHERE t9.UM_ATTR_NAME=''scimId'') t2
+                ON t1.UM_ID = t2.UM_ID
+                WHERE t2.UM_ID IS NULL';
+            COMMIT;
+           
+        -- Insert uid claim for users who didn't have a uid
+            EXECUTE IMMEDIATE 'INSERT INTO UM_USER_ATTRIBUTE (UM_USER_ID, UM_ATTR_NAME, UM_ATTR_VALUE, UM_PROFILE_ID, UM_TENANT_ID)
+                SELECT t1.UM_ID, ''uid'', t1.UM_USER_NAME, ''default'', -1234
+                FROM TMP_UM_USER_UUID_CHUNK t1
+                LEFT JOIN 
+                    (SELECT DISTINCT(t8.UM_ID), t8.UM_USER_NAME
+                    FROM TMP_UM_USER_UUID_CHUNK t8
+                    LEFT JOIN UM_USER_ATTRIBUTE t9
+                    ON t8.UM_ID = t9.UM_USER_ID
+                    WHERE t9.UM_ATTR_NAME=''uid'') t2
+                ON t1.UM_ID = t2.UM_ID
+                WHERE t2.UM_ID IS NULL';
+            COMMIT;
+       
+             IF (NOT forceUpdate AND scimEnable) THEN
+                     
+               EXECUTE IMMEDIATE 'CREATE TABLE TMP_UM_USER_SCIM AS
+						 (SELECT t1.UM_ID, t1.UM_USER_ID,t2.UM_ATTR_VALUE FROM TMP_UM_USER_UUID_CHUNK t1 
+							INNER JOIN UM_USER_ATTRIBUTE t2 ON t1.UM_ID = t2.UM_USER_ID WHERE t2.UM_ATTR_NAME=''scimId'')';
+            COMMIT;
+			EXECUTE IMMEDIATE'ALTER TABLE TMP_UM_USER_SCIM
+								ADD CONSTRAINT pknew PRIMARY KEY (UM_ID)
+                                ADD CONSTRAINT newkey UNIQUE (UM_ATTR_VALUE)';
+                                           COMMIT;
+
+               EXECUTE IMMEDIATE 'UPDATE 
+                (SELECT t2.UM_ATTR_VALUE, t1.UM_USER_ID as UUID
+                FROM UM_USER t1
+                INNER JOIN TMP_UM_USER_SCIM t2 
+                ON t1.UM_ID = t2.UM_ID
+                ) t
+                SET t.UUID = t.UM_ATTR_VALUE';
+               COMMIT;
+
+			   EXECUTE IMMEDIATE 'DROP TABLE TMP_UM_USER_SCIM';
+            COMMIT;
+
+             END IF;
+            totalMigrated := totalMigrated + chunkCount;
+            EXECUTE IMMEDIATE 'DROP TABLE TMP_UM_USER_UUID_CHUNK';
+            COMMIT;
+
+ 		END LOOP;
+ 		
+        EXECUTE IMMEDIATE 'DROP TABLE TMP_UM_USER_UUID';
+      
+ 		COMMIT;
+		
+	END;
+
+END;

--- a/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/postgres.sql
+++ b/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/postgres.sql
@@ -1,0 +1,92 @@
+
+CREATE OR REPLACE FUNCTION USERID_MIGRATION_SP() RETURNS VOID
+AS $$
+DECLARE 
+    chunkSize INT := 1000;
+    threshold INT := 9999999;
+    totalMigrated INT := 0;
+    chunkCount INT := 1;
+    query varchar(200);
+    offset INT := 0;
+    forceUpdate BOOLEAN := FALSE;
+    scimEnable BOOLEAN := TRUE;
+BEGIN
+    
+    EXECUTE 'CREATE TABLE TMP_UM_USER_UUID AS (SELECT UM_USER_NAME,UM_ID, UM_USER_ID FROM UM_USER)';
+
+    WHILE (chunkCount!=0 and totalMigrated < threshold ) LOOP
+
+        offset:=totalMigrated+chunkSize;
+
+        CREATE TABLE TMP_UM_USER_UUID_CHUNK as SELECT * FROM TMP_UM_USER_UUID offset totalMigrated LIMIT chunkSize;
+            
+        execute 'ALTER TABLE TMP_UM_USER_UUID_CHUNK
+        ADD CONSTRAINT pk PRIMARY KEY (UM_ID)';
+
+        SELECT COUNT(*) FROM TMP_UM_USER_UUID_CHUNK INTO chunkCount;
+        -- If it is force update then update the existing scim id with newly generated um_user_id in um_user table
+        IF forceUpdate THEN
+            execute 'UPDATE UM_USER_ATTRIBUTE as t1
+            SET UM_ATTR_VALUE = t2.UM_USER_ID
+            FROM TMP_UM_USER_UUID_CHUNK as t2 
+            WHERE t1.UM_USER_ID = t2.UM_ID
+            AND t1.UM_ATTR_VALUE != t2.UM_USER_ID
+            and t1.UM_ATTR_NAME=''scimId''';
+        END IF;
+
+        -- insert scim id claim for the users who doesnt have one
+        execute 'INSERT INTO UM_USER_ATTRIBUTE (UM_USER_ID, UM_ATTR_NAME, UM_ATTR_VALUE, UM_PROFILE_ID, UM_TENANT_ID)
+        SELECT t1.UM_ID, ''scimId'', t1.UM_USER_ID, ''default'', -1234
+        FROM TMP_UM_USER_UUID_CHUNK as t1
+        LEFT JOIN 
+        (SELECT DISTINCT(t8.UM_ID), t8.UM_USER_NAME
+        FROM TMP_UM_USER_UUID_CHUNK as t8
+        LEFT JOIN UM_USER_ATTRIBUTE as t9
+        ON t8.UM_ID = t9.UM_USER_ID
+        WHERE t9.UM_ATTR_NAME=''scimId'') as t2
+        ON t1.UM_ID = t2.UM_ID
+        WHERE t2.UM_ID IS NULL';
+
+        -- insert  uid claim for the users who doesnt have one
+        execute 'INSERT INTO UM_USER_ATTRIBUTE (UM_USER_ID, UM_ATTR_NAME, UM_ATTR_VALUE, UM_PROFILE_ID, UM_TENANT_ID)
+        SELECT t1.UM_ID, ''uid'', t1.UM_USER_NAME, ''default'', -1234
+        FROM TMP_UM_USER_UUID_CHUNK as t1
+        LEFT JOIN 
+        (SELECT DISTINCT(t8.UM_ID), t8.UM_USER_NAME
+        FROM TMP_UM_USER_UUID_CHUNK as t8
+        LEFT JOIN UM_USER_ATTRIBUTE as t9
+        ON t8.UM_ID = t9.UM_USER_ID
+        WHERE t9.UM_ATTR_NAME=''uid'') as t2
+        ON t1.UM_ID = t2.UM_ID
+        WHERE t2.UM_ID IS NULL';
+
+        -- if scim enable and not a force update then generated um_user_id wll be replaced with user's existing scim claim value
+        IF (NOT forceUpdate AND scimEnable) THEN
+
+            CREATE TABLE TMP_UM_USER_SCIM AS
+            (SELECT t1.UM_ID, t1.UM_USER_ID,t2.UM_ATTR_VALUE FROM TMP_UM_USER_UUID_CHUNK t1 
+            INNER JOIN UM_USER_ATTRIBUTE t2 ON t1.UM_ID = t2.UM_USER_ID WHERE t2.UM_ATTR_NAME='scimId');
+
+            ALTER TABLE TMP_UM_USER_SCIM
+            ADD PRIMARY KEY (UM_ID),
+            ADD UNIQUE(UM_ATTR_VALUE);
+
+            UPDATE UM_USER as t1
+            set um_user_id = t2.UM_ATTR_VALUE
+            from TMP_UM_USER_SCIM as t2
+            where t1.UM_ID = t2.UM_ID;
+
+            drop table TMP_UM_USER_SCIM;
+
+        END IF;
+        totalMigrated := totalMigrated + chunkCount;
+        DROP TABLE TMP_UM_USER_UUID_CHUNK;
+
+    END LOOP;
+
+    DROP TABLE TMP_UM_USER_UUID;
+
+END;
+
+$$ LANGUAGE plpgsql;
+

--- a/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/readme.md
+++ b/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/readme.md
@@ -1,4 +1,4 @@
-1. Execute the relevent stored procedure to migrate the userid mannually, if the "UserIDMigrator" step takes too long via the migration cleint.
+1. Execute the relevent stored procedure to migrate the userid mannually, if the "UserIDMigrator" step takes too long via the migration client.
 2. Comment out the UserIDMigrator section as shown below in the <identity-migration-resources>/components/org.wso2.is.migration/migration-resources/migration-config.yaml file
 ```
 version: "5.10.0"

--- a/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/readme.md
+++ b/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/readme.md
@@ -1,0 +1,35 @@
+1. Execute the relevent stored procedure to migrate the userid mannually.
+2. Comment out the UserIDMigrator section as shown below in the <identity-migration-resources>/components/org.wso2.is.migration/migration-resources/migration-config.yaml file
+```
+version: "5.10.0"
+   migratorConfigs:
+   -
+....
+  #  -
+    #  name: "UserIDMigrator"
+    #  order: 10
+    #  parameters:
+       # Migrate all the tenants and all the user store domains in it.
+       # migrateAll: true
+       # Absolute path for the dry report. This is required in the dry run mode.
+       # reportPath:
+       # If migrating only few tenants, this configuration should be repeated for each tenant. (Optional)
+       # tenant1:
+         # Domain name of the tenant. (Mandatory)
+         # tenantDomain: carbon.super
+         # Number of users to be updated in each iteration. (Optional)
+         # increment: 100
+         # Where should the migration should start from (Offset). This is useful if the migration stopped middle and needs to restart. (Optional)
+         # startingPoint: 0
+         # Whether SCIM enabled for user stores in this tenant. (Optional)
+         # scimEnabled: false
+         # List of comma separated domain names which should be migrated in this domain. (Optional)
+         # migratingDomains: "PRIMARY"
+         # Mark whether user IDs should be updated even though there is already an ID there. (Optional)
+         # forceUpdateUserId: true
+
+
+ -
+   version: "5.11.0"
+```
+3. Then run the migration

--- a/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/readme.md
+++ b/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/readme.md
@@ -1,4 +1,4 @@
-1. Execute the relevent stored procedure to migrate the userid mannually.
+1. Execute the relevent stored procedure to migrate the userid mannually, if the "UserIDMigrator" step takes too long via the migration cleint.
 2. Comment out the UserIDMigrator section as shown below in the <identity-migration-resources>/components/org.wso2.is.migration/migration-resources/migration-config.yaml file
 ```
 version: "5.10.0"

--- a/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/readme.md
+++ b/components/org.wso2.is.migration/migration-resources/5.10.0/stored-procedures/user_id_migration/readme.md
@@ -1,4 +1,4 @@
-1. Execute the relevent stored procedure to migrate the userid mannually, if the "UserIDMigrator" step takes too long via the migration client.
+1. Execute the relevent stored procedure "<migration-resources>/5.10.0/stored-procedures/user_id_migration/<db_type>.sql" to migrate the userids mannually. (This is required only if the "UserIDMigrator" step takes too long via the migration client.)
 2. Comment out the UserIDMigrator section as shown below in the <identity-migration-resources>/components/org.wso2.is.migration/migration-resources/migration-config.yaml file
 ```
 version: "5.10.0"


### PR DESCRIPTION
## Purpose
> The default userid migration from the migration client would take long time if the user base is large. Hence using the stored procedures userid migration can be performed manually first and run the migration client later without the userid migration step in the is510.  
