### PR TITLE
Define app portal enum in-house

### DIFF
--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/AppPortal.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/AppPortal.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.is.migration.util;
+
+/**
+ * App portal enum class.
+ */
+public enum AppPortal {
+
+    USER_PORTAL("User Portal", "This is the user portal application.", "USER_PORTAL", "/user-portal/login"),
+    ADMIN_PORTAL("Admin Portal", "This is the admin portal application.", "ADMIN_PORTAL", "/admin-portal/login");
+
+    private final String name;
+    private final String description;
+    private final String consumerKey;
+    private final String path;
+
+    private AppPortal(String name, String description, String consumerKey, String path) {
+        this.name = name;
+        this.description = description;
+        this.consumerKey = consumerKey;
+        this.path = path;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public String getConsumerKey() {
+        return this.consumerKey;
+    }
+
+    public String getPath() {
+        return this.path;
+    }
+}

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/TenantPortalMigratorUtil.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/TenantPortalMigratorUtil.java
@@ -48,7 +48,6 @@ import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.CarbonUtils;
-import org.wso2.identity.apps.common.util.AppPortalConstants;
 
 import java.util.Arrays;
 import java.util.List;
@@ -93,8 +92,8 @@ public class TenantPortalMigratorUtil {
         UserRealm userRealm = ISMigrationServiceDataHolder.getRegistryService().getUserRealm(tenantId);
         String adminUsername = userRealm.getRealmConfiguration().getAdminUserName();
 
-        for (AppPortalConstants.AppPortal appPortal : AppPortalConstants.AppPortal.values()) {
-            if (appPortal.equals(AppPortalConstants.AppPortal.ADMIN_PORTAL)) {
+        for (AppPortal appPortal : AppPortal.values()) {
+            if (appPortal.equals(AppPortal.ADMIN_PORTAL)) {
                 String productVersion = CarbonUtils.getServerConfiguration().getFirstProperty("Version");
                 // Skip admin portal creation for IS 5.10.0.
                 if (StringUtils.isBlank(productVersion) || !productVersion.startsWith("5.11.0")) {


### PR DESCRIPTION
## Purpose
Since the 5.11.0 codebase doesn't have the AppPortal enum as required, the migration client fails. Therefore defining it in the code. 

The enum has been changed to other names: https://github.com/wso2/identity-apps/blob/master/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalConstants.java

Resolves https://github.com/wso2/product-is/issues/11900
