### PR TITLE
Add super-tenant migration skip support to Email Template migration

### DIFF
--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/internal/ISMigrationServiceComponent.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/internal/ISMigrationServiceComponent.java
@@ -20,7 +20,6 @@ import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.base.api.ServerConfigurationService;
-import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.migrate.MigrationClient;
 import org.wso2.carbon.is.migration.MigrationClientImpl;
 import org.wso2.carbon.registry.core.service.RegistryService;
@@ -35,8 +34,6 @@ import org.wso2.carbon.user.core.service.RealmService;
  * cardinality="1..1" policy="dynamic"  bind="setServerConfigurationService" unbind="unsetServerConfigurationService"
  * @scr.reference name="registry.service" interface="org.wso2.carbon.registry.core.service.RegistryService"
  * cardinality="1..1" policy="dynamic"  bind="setRegistryService" unbind="unsetRegistryService"
- * @scr.reference name="application.mgt.service" interface="org.wso2.carbon.identity.application.mgt.ApplicationManagementService"
- * cardinality="1..1" policy="dynamic"  bind="setApplicationManagementService" unbind="unsetApplicationManagementService"
  */
 public class ISMigrationServiceComponent {
 
@@ -59,7 +56,6 @@ public class ISMigrationServiceComponent {
         } catch (Throwable e) {
             log.error("Error while initiating Config component", e);
         }
-
     }
 
     /**
@@ -118,15 +114,5 @@ public class ISMigrationServiceComponent {
     protected void unsetRegistryService(RegistryService registryService) {
 
         ISMigrationServiceDataHolder.setRegistryService(null);
-    }
-
-    protected void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
-
-        ISMigrationServiceDataHolder.setApplicationManagementService(applicationManagementService);
-    }
-
-    protected void unsetApplicationManagementService(ApplicationManagementService applicationManagementService) {
-
-        ISMigrationServiceDataHolder.setApplicationManagementService(null);
     }
 }

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/internal/ISMigrationServiceDataHolder.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/internal/ISMigrationServiceDataHolder.java
@@ -16,7 +16,6 @@
 package org.wso2.carbon.is.migration.internal;
 
 import org.wso2.carbon.base.api.ServerConfigurationService;
-import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.registry.core.service.TenantRegistryLoader;
@@ -35,8 +34,6 @@ public class ISMigrationServiceDataHolder {
     private static RealmService realmService;
 
     private static ServerConfigurationService serverConfigurationService;
-
-    private static ApplicationManagementService applicationManagementService;
 
     //Tenant registry loader which is used to load tenant registry
     private static TenantRegistryLoader tenantRegLoader;
@@ -153,15 +150,5 @@ public class ISMigrationServiceDataHolder {
     public static void setServerConfigurationService(ServerConfigurationService serverConfigurationService) {
 
         ISMigrationServiceDataHolder.serverConfigurationService = serverConfigurationService;
-    }
-
-    public static void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
-
-        ISMigrationServiceDataHolder.applicationManagementService = applicationManagementService;
-    }
-
-    public static ApplicationManagementService getApplicationManagementService() {
-
-        return applicationManagementService;
     }
 }

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/EmailTemplateDataMigrator.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/EmailTemplateDataMigrator.java
@@ -116,7 +116,11 @@ public class EmailTemplateDataMigrator extends Migrator {
         List<NotificationTemplate> emailTemplates = loadEmailTemplates();
         try {
             // Migrate super tenant.
-            migrateTenantEmailTemplates(emailTemplates, SUPER_TENANT_DOMAIN_NAME);
+            boolean skipSuperTenantMigration = Boolean.parseBoolean(
+                    getMigratorConfig().getParameterValue(Constant.SKIP_SUPER_TENANT_EMAIL_TEMPLATE_MIGRATION));
+            if (!skipSuperTenantMigration) {
+                migrateTenantEmailTemplates(emailTemplates, SUPER_TENANT_DOMAIN_NAME);
+            }
 
             // Migrate other tenants.
             Set<Tenant> tenants = Utility.getTenants();

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/Constant.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/Constant.java
@@ -48,7 +48,7 @@ public class Constant {
     public static final String DELIMITER = "DELIMITER";
 
     public static final String EMAIL_TEMPLATE_PATH = "/identity/email";
-    public static final String SKIP_SUPER_TENANT_EMAIL_TEMPLATE_MIGRATION = "skipSuperTenantMigration";
+    public static final String SKIP_SUPER_TENANT_EMAIL_TEMPLATE_MIGRATION = "skipSuperTenantEmailTemplateMigration";
     public static final String TEMPLATE_TYPE = "type";
     public static final String TEMPLATE_TYPE_DISPLAY_NAME = "display";
     public static final String TEMPLATE_LOCALE = "locale";

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/Constant.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/Constant.java
@@ -48,6 +48,7 @@ public class Constant {
     public static final String DELIMITER = "DELIMITER";
 
     public static final String EMAIL_TEMPLATE_PATH = "/identity/email";
+    public static final String SKIP_SUPER_TENANT_EMAIL_TEMPLATE_MIGRATION = "skipSuperTenantMigration";
     public static final String TEMPLATE_TYPE = "type";
     public static final String TEMPLATE_TYPE_DISPLAY_NAME = "display";
     public static final String TEMPLATE_LOCALE = "locale";

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/TenantPortalMigratorUtil.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/TenantPortalMigratorUtil.java
@@ -34,6 +34,9 @@ import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthent
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementServiceImpl;
+import org.wso2.carbon.identity.application.mgt.ApplicationMgtSystemConfig;
+import org.wso2.carbon.identity.application.mgt.dao.ApplicationDAO;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth.OAuthUtil;
@@ -86,8 +89,7 @@ public class TenantPortalMigratorUtil {
             throws IdentityApplicationManagementException, IdentityOAuthAdminException, RegistryException,
             UserStoreException {
 
-        ApplicationManagementService applicationMgtService = ISMigrationServiceDataHolder
-                .getApplicationManagementService();
+        ApplicationDAO applicationDAO = ApplicationMgtSystemConfig.getInstance().getApplicationDAO();
 
         UserRealm userRealm = ISMigrationServiceDataHolder.getRegistryService().getUserRealm(tenantId);
         String adminUsername = userRealm.getRealmConfiguration().getAdminUserName();
@@ -100,7 +102,7 @@ public class TenantPortalMigratorUtil {
                     continue;
                 }
             }
-            if (applicationMgtService.getApplicationExcludingFileBasedSPs(appPortal.getName(), tenantDomain) == null) {
+            if (applicationDAO.getApplication(appPortal.getName(), tenantDomain) == null) {
                 // Initiate portal
                 String consumerSecret = OAuthUtil.getRandomNumber();
                 List<String> grantTypes = Arrays.asList(AUTHORIZATION_CODE, REFRESH_TOKEN, GRANT_TYPE_ACCOUNT_SWITCH);
@@ -153,8 +155,9 @@ public class TenantPortalMigratorUtil {
         claimConfig.setLocalClaimDialect(true);
         serviceProvider.setClaimConfig(claimConfig);
 
-        ISMigrationServiceDataHolder.getApplicationManagementService()
-                .createApplication(serviceProvider, tenantDomain, appOwner);
+        ApplicationManagementService applicationManagementService = ApplicationManagementServiceImpl.getInstance();
+        applicationManagementService.createApplication(serviceProvider, tenantDomain, appOwner);
+
         if (log.isDebugEnabled()) {
             log.debug(String.format("User portal application is created successfully for tenant %s.", tenantDomain));
         }


### PR DESCRIPTION
### Purpose
This PR fixes the following two;
- Add super-tenant migration skipping support to email template migrations.
- Remove cyclic dependency issue occurred due to **ApplicationManagementService** reference in **ISMigrationServiceComponent**.