### PR TITLE
Adding app inbound auth migration client

### DIFF
--- a/components/org.wso2.is.migration/migration-resources/migration-config.yaml
+++ b/components/org.wso2.is.migration/migration-resources/migration-config.yaml
@@ -568,3 +568,6 @@ versions:
         consoleRedirectUrl: "regexp=(https://localhost:9443/console|https://localhost:9443/t/(.*)/console)"
         myaccountRedirectUrl: "regexp=(https://localhost:9443/myaccount|https://localhost:9443/t/(.*)/myaccount)"
         accessTokenBindingType: "cookie"
+
+   - name: "AppInboundAuthMigrator"
+     order: 16

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v600/migrator/AppInboundAuthMigrator.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v600/migrator/AppInboundAuthMigrator.java
@@ -45,7 +45,7 @@ public class AppInboundAuthMigrator extends Migrator {
     private static final String GET_AUTH_DATA = "SELECT PROP_NAME FROM SP_INBOUND_AUTH " +
             "WHERE APP_ID = ? AND INBOUND_AUTH_TYPE = ?";
     private static final String DELETE_MULTIPLE_AUTH_ENTRIES =
-            "DELETE FROM SP_INBOUND_AUTH WHERE APP_ID = ? AND INBOUND_AUTH_TYPE = ? OR INBOUND_AUTH_TYPE = ?";
+            "DELETE FROM SP_INBOUND_AUTH WHERE APP_ID = ? AND (INBOUND_AUTH_TYPE = ? OR INBOUND_AUTH_TYPE = ?)";
     private static final String DELETE_AUTH_ENTRY = "DELETE from SP_INBOUND_AUTH WHERE APP_ID = ? AND " +
             "INBOUND_AUTH_TYPE = ?";
 
@@ -129,7 +129,7 @@ public class AppInboundAuthMigrator extends Migrator {
                                 try (PreparedStatement preparedStatement =
                                              connection.prepareStatement(DELETE_AUTH_ENTRY)) {
                                     preparedStatement.setInt(1, code);
-                                    preparedStatement.setString(2, OPENID);
+                                    preparedStatement.setString(2, PASSIVESTS);
                                     preparedStatement.executeUpdate();
                                 } catch (SQLException e) {
                                     JDBCPersistenceUtil.rollbackTransaction(connection);

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v600/migrator/AppInboundAuthMigrator.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v600/migrator/AppInboundAuthMigrator.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.is.migration.service.v600.migrator;
+
+import org.apache.commons.lang3.ObjectUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.identity.core.migrate.MigrationClientException;
+import org.wso2.carbon.is.migration.service.Migrator;
+import org.wso2.carbon.is.migration.service.v530.util.JDBCPersistenceUtil;
+import org.wso2.carbon.is.migration.util.Schema;
+
+import java.sql.*;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.TimeZone;
+
+/**
+ * Migration implementation for migrating recovery data.
+ */
+public class AppInboundAuthMigrator extends Migrator {
+
+    private static final Logger log = LoggerFactory.getLogger(AppInboundAuthMigrator.class);
+    private static final String PASSIVESTS = "passivests";
+    private static final String OPENID = "openid";
+    private static final String GET_APP_ID_COUNT =
+            "SELECT APP_ID, COUNT(APP_ID) as count FROM SP_INBOUND_AUTH GROUP BY APP_ID HAVING COUNT(APP_ID) >= 2";
+    private static final String ERROR_DELETING_AUTH_DATA = "An error occurred while deleting auth data.";
+    private static final String GET_AUTH_DATA = "SELECT PROP_NAME FROM SP_INBOUND_AUTH " +
+            "WHERE APP_ID = ? AND INBOUND_AUTH_TYPE = ?";
+    private static final String DELETE_MULTIPLE_AUTH_ENTRIES =
+            "DELETE FROM SP_INBOUND_AUTH WHERE APP_ID = ? AND INBOUND_AUTH_TYPE = ? OR INBOUND_AUTH_TYPE = ?";
+    private static final String DELETE_AUTH_ENTRY = "DELETE from SP_INBOUND_AUTH WHERE APP_ID = ? AND " +
+            "INBOUND_AUTH_TYPE = ?";
+
+    @Override
+    public void dryRun() throws MigrationClientException {
+
+        log.info("Dry run capability not implemented in {} migrator.", this.getClass().getName());
+    }
+
+    @Override
+    public void migrate() throws MigrationClientException {
+
+        log.info("Started migrating app inbound authentication data.");
+        HashMap<Integer, Integer> appids = getAppIDCountFromSPInboundAuthTable();
+        deleteDuplicateData(appids);
+        log.info("Inbound authentication data migration complete.");
+    }
+
+    // Function to retrieve app ID's along with their corresponding count.
+    private HashMap<Integer, Integer>  getAppIDCountFromSPInboundAuthTable() throws MigrationClientException {
+
+        log.info("Reading data from SP Auth table.");
+        HashMap<Integer, Integer> appids = new HashMap<>();
+
+        try (Connection connection = getDataSource(Schema.IDENTITY.getName()).getConnection();
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(GET_APP_ID_COUNT)) {
+            while (resultSet.next()) {
+                Integer appid = resultSet.getInt("app_id");
+                Integer count = resultSet.getInt("count");
+                appids.put(appid, count);
+            }
+            return appids;
+        } catch (SQLException e) {
+            throw new MigrationClientException("An error occurred while reading auth data.", e);
+        }
+    }
+
+    // Function that contains the logic to delete duplicate data entries
+    private void deleteDuplicateData(HashMap<Integer, Integer>  appids) throws MigrationClientException {
+
+        if (!appids.isEmpty()) {
+            log.info("Removing duplicate service provider entries.");
+        }
+        try (Connection connection = getDataSource(Schema.IDENTITY.getName()).getConnection()) {
+            boolean autoCommitStatus = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+            for (Integer code : appids.keySet()) {
+                Integer count = appids.get(code);
+                if (count == 3){
+                    try (PreparedStatement preparedStatement = connection.prepareStatement(DELETE_MULTIPLE_AUTH_ENTRIES)) {
+                        preparedStatement.setInt(1, code);
+                        preparedStatement.setString(2,PASSIVESTS);
+                        preparedStatement.setString(3,OPENID);
+                        preparedStatement.executeUpdate();
+                    } catch (SQLException e) {
+                        JDBCPersistenceUtil.rollbackTransaction(connection);
+                        connection.setAutoCommit(autoCommitStatus);
+                        throw new MigrationClientException(ERROR_DELETING_AUTH_DATA, e);
+                    }
+                }
+                else if (count == 2) {
+                    try (PreparedStatement retrieveAuthData = connection.prepareStatement(GET_AUTH_DATA)) {
+                        retrieveAuthData.setInt(1,code);
+                        retrieveAuthData.setString(2,PASSIVESTS);
+                        ResultSet resultSet = retrieveAuthData.executeQuery();
+                        if (resultSet.next()) {
+                            String propName = resultSet.getString("PROP_NAME");
+                            if ("passiveSTSWReply".equalsIgnoreCase(propName)) {
+                                try (PreparedStatement preparedStatement =
+                                             connection.prepareStatement(DELETE_AUTH_ENTRY)) {
+                                    preparedStatement.setInt(1, code);
+                                    preparedStatement.setString(2, OPENID);
+                                    preparedStatement.executeUpdate();
+                                } catch (SQLException e) {
+                                    JDBCPersistenceUtil.rollbackTransaction(connection);
+                                    connection.setAutoCommit(autoCommitStatus);
+                                    throw new MigrationClientException(ERROR_DELETING_AUTH_DATA, e);
+                                }
+                            } else {
+                                try (PreparedStatement preparedStatement =
+                                             connection.prepareStatement(DELETE_AUTH_ENTRY)) {
+                                    preparedStatement.setInt(1, code);
+                                    preparedStatement.setString(2, OPENID);
+                                    preparedStatement.executeUpdate();
+                                } catch (SQLException e) {
+                                    JDBCPersistenceUtil.rollbackTransaction(connection);
+                                    connection.setAutoCommit(autoCommitStatus);
+                                    throw new MigrationClientException(ERROR_DELETING_AUTH_DATA, e);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            JDBCPersistenceUtil.commitTransaction(connection);
+            connection.setAutoCommit(autoCommitStatus);
+        } catch (SQLException e) {
+            throw new MigrationClientException(ERROR_DELETING_AUTH_DATA, e);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
> To resolve the issue of service provider duplication when migrating from IS 5.3.0 to 6.0.0. Ref: https://github.com/wso2/product-is/issues/14726

## Approach
> An additional migration client with database queries was included to remove duplicate entries. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Migrations (if applicable)
> Migration from 5.3.0 to 6.0.0 has been tested

## Test environment
> JDK 8/11 , MacOS  Big Sur 11.6.8
 