### PR TITLE
Add support for separate registry DB

### DIFF
--- a/components/org.wso2.is.migration/migration-resources/migration-config.yaml
+++ b/components/org.wso2.is.migration/migration-resources/migration-config.yaml
@@ -8,6 +8,7 @@ migrateVersion: "6.x.x"
 continueOnError: "false"
 batchUpdate: "true"
 ignoreForInactiveTenants: "true"
+isSeparateRegDB: "false"
 
 migrateTenantRange: "false"
 migrationStartingTenantID: "0"

--- a/components/org.wso2.is.migration/migration-resources/migration-config.yaml
+++ b/components/org.wso2.is.migration/migration-resources/migration-config.yaml
@@ -8,7 +8,7 @@ migrateVersion: "6.x.x"
 continueOnError: "false"
 batchUpdate: "true"
 ignoreForInactiveTenants: "true"
-isSeparateRegDB: "false"
+isSeparateRegistryDB: "false"
 
 migrateTenantRange: "false"
 migrationStartingTenantID: "0"

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/DataSourceManager.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/DataSourceManager.java
@@ -264,6 +264,10 @@ public class DataSourceManager {
                     try {
                         ctx = new InitialContext();
                         DataSource regDataSource = (DataSource) ctx.lookup(dataSourceName);
+                        if (regDataSource == null) {
+                            throw new MigrationClientException(Constant.MIGRATION_LOG + "Error when initiating " +
+                                    "registry datasource.");
+                        }
                         regDataSources.put(dataSourceName, regDataSource);
                     } catch (NamingException e) {
                         throw new MigrationClientException("Error when reading Registry Data Source configurations.",

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/DataSourceManager.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/DataSourceManager.java
@@ -79,6 +79,8 @@ public class DataSourceManager {
             return consentDataSource;
         } else if (schema.getName().equals(Schema.UMA.getName())) {
             return dataSource;
+        } else if (schema.getName().equals(Schema.REG.getName())) {
+            return dataSource;
         }
         throw new MigrationClientException("DataSource is not available for " + schema);
     }
@@ -92,6 +94,8 @@ public class DataSourceManager {
         } else if (schema.equals(Schema.CONSENT.getName())) {
             return consentDataSource;
         } else if (schema.equals(Schema.UMA.getName())) {
+            return dataSource;
+        } else if (schema.equals(Schema.REG.getName())) {
             return dataSource;
         }
         throw new MigrationClientException("DataSource is not available for " + schema);

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/DataSourceManager.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/DataSourceManager.java
@@ -252,8 +252,8 @@ public class DataSourceManager {
             while (dbConfigs.hasNext()) {
                 OMElement dbConfig = (OMElement) dbConfigs.next();
                 String dbName = dbConfig.getAttributeValue(new QName("name"));
-                if (dbName.equals("govregistry")) {
-                    // or the datasource name can be hard-coded to WSO2REG_DB
+                if (dbName.equals("wso2registry")) {
+                    // Separating only wso2 registry. Or else the datasource name can be hard-coded to WSO2REG_DB
                     OMElement dataSource = dbConfig.getFirstChildWithName(new QName("dataSource"));
                     if (dataSource != null) {
                         String dataSourceName = dataSource.getText();

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/DataSourceManager.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/DataSourceManager.java
@@ -114,6 +114,7 @@ public class DataSourceManager {
      * Return registry datasources.
      */
     public Map<String, DataSource> getRegistryDataSources() throws MigrationClientException {
+
         return regDataSources;
     }
 

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/DataSourceManager.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/DataSourceManager.java
@@ -35,8 +35,12 @@ import org.wso2.carbon.utils.dbcreator.DatabaseCreator;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
@@ -44,10 +48,6 @@ import javax.naming.NamingException;
 import javax.sql.DataSource;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
-import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
 
 /**
  * Class for datasource management.
@@ -248,7 +248,7 @@ public class DataSourceManager {
             }
 
             if (inStream == null) {
-                throw new MigrationClientException("Error when initiating the Registry Data Source.");
+                throw new MigrationClientException("Error when reading the Registry Data Source configurations.");
             }
             StAXOMBuilder builder = new StAXOMBuilder(CarbonUtils.replaceSystemVariablesInXml(inStream));
             OMElement configElement = builder.getDocumentElement();
@@ -266,7 +266,8 @@ public class DataSourceManager {
                         DataSource regDataSource = (DataSource) ctx.lookup(dataSourceName);
                         regDataSources.put(dataSourceName, regDataSource);
                     } catch (NamingException e) {
-                        throw new MigrationClientException("Error when initiating Registry Data Source.", e);
+                        throw new MigrationClientException("Error when reading Registry Data Source configurations.",
+                                e);
                     }
                 }
             }

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/config/Config.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/config/Config.java
@@ -45,6 +45,8 @@ public class Config {
     private String currentEncryptionAlgorithm;
     private String migratedEncryptionAlgorithm;
 
+    private boolean isSeparateRegDB;
+
     private Config() {
 
     }
@@ -209,5 +211,13 @@ public class Config {
     public void setMigratedEncryptionAlgorithm(String migratedEncryptionAlgorithm) {
 
         this.migratedEncryptionAlgorithm = migratedEncryptionAlgorithm;
+    }
+
+    public boolean isSeparateRegDB() {
+        return isSeparateRegDB;
+    }
+
+    public void setSeparateRegDB(boolean separateRegDB) {
+        isSeparateRegDB = separateRegDB;
     }
 }

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/config/Config.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/config/Config.java
@@ -45,7 +45,7 @@ public class Config {
     private String currentEncryptionAlgorithm;
     private String migratedEncryptionAlgorithm;
 
-    private boolean isSeparateRegDB;
+    private boolean isSeparateRegistryDB;
 
     private Config() {
 
@@ -213,11 +213,11 @@ public class Config {
         this.migratedEncryptionAlgorithm = migratedEncryptionAlgorithm;
     }
 
-    public boolean isSeparateRegDB() {
-        return isSeparateRegDB;
+    public boolean isSeparateRegistryDB() {
+        return isSeparateRegistryDB;
     }
 
-    public void setSeparateRegDB(boolean separateRegDB) {
-        isSeparateRegDB = separateRegDB;
+    public void setSeparateRegistryDB(boolean separateRegistryDB) {
+        isSeparateRegistryDB = separateRegistryDB;
     }
 }

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/Migrator.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/Migrator.java
@@ -34,7 +34,7 @@ public abstract class Migrator {
     public static final String CONTINUE_ON_ERROR = "continueOnError";
     public static final String BATCH_UPDATE = "batchUpdate";
     public static final String IGNORE_FOR_INACTIVE_TENANTS = "ignoreForInactiveTenants";
-    public static final String IS_SEPARATE_REG_DB = "isSeparateRegDB";
+    public static final String IS_SEPARATE_REGISTRY_DB = "isSeparateRegistryDB";
 
     private MigratorConfig migratorConfig;
     private Version versionConfig;
@@ -93,13 +93,13 @@ public abstract class Migrator {
         return Boolean.parseBoolean(ignoreForInactiveTenants);
     }
 
-    public boolean isSeparateRegDB() {
+    public boolean isSeparateRegistryDB() {
 
-        String isSeparateRegDB = getMigratorConfig().getParameterValue(IS_SEPARATE_REG_DB);
-        if (StringUtils.isBlank(isSeparateRegDB)) {
-            return Config.getInstance().isSeparateRegDB();
+        String isSeparateRegistryDB = getMigratorConfig().getParameterValue(IS_SEPARATE_REGISTRY_DB);
+        if (StringUtils.isBlank(isSeparateRegistryDB)) {
+            return Config.getInstance().isSeparateRegistryDB();
         }
-        return Boolean.parseBoolean(isSeparateRegDB);
+        return Boolean.parseBoolean(isSeparateRegistryDB);
     }
 
     public String getSchema() {

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/Migrator.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/Migrator.java
@@ -33,6 +33,7 @@ public abstract class Migrator {
     public static final String CONTINUE_ON_ERROR = "continueOnError";
     public static final String BATCH_UPDATE = "batchUpdate";
     public static final String IGNORE_FOR_INACTIVE_TENANTS = "ignoreForInactiveTenants";
+    public static final String IS_SEPARATE_REG_DB = "isSeparateRegDB";
 
     private MigratorConfig migratorConfig;
     private Version versionConfig;
@@ -84,6 +85,15 @@ public abstract class Migrator {
             return Config.getInstance().isIgnoreForInactiveTenants();
         }
         return Boolean.parseBoolean(ignoreForInactiveTenants);
+    }
+
+    public boolean isSeparateRegDB() {
+
+        String isSeparateRegDB = getMigratorConfig().getParameterValue(IS_SEPARATE_REG_DB);
+        if (StringUtils.isBlank(isSeparateRegDB)) {
+            return Config.getInstance().isSeparateRegDB();
+        }
+        return Boolean.parseBoolean(isSeparateRegDB);
     }
 
     public String getSchema() {

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/Migrator.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/Migrator.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.is.migration.config.MigratorConfig;
 import org.wso2.carbon.is.migration.config.Version;
 
 import javax.sql.DataSource;
+import java.util.Map;
 
 /**
  * Abstract class for Migrator contract. All migration implementation should be implemented from this class.
@@ -58,6 +59,11 @@ public abstract class Migrator {
 
         DataSource dataSource = DataSourceManager.getInstance().getDataSource(getSchema());
         return dataSource;
+    }
+
+    public Map<String, DataSource> getRegistryDataSources() throws MigrationClientException {
+
+        return DataSourceManager.getInstance().getRegistryDataSources();
     }
 
     public boolean isContinueOnError() {

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/SchemaMigrator.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/SchemaMigrator.java
@@ -61,7 +61,10 @@ public class SchemaMigrator extends Migrator {
         try {
             conn = getDataSource().getConnection();
             migrateWithConnection(conn);
-            if (isSeparateRegDB() && Objects.equals(getSchema(), "reg")) {
+            /* To support migration of registry and primary JDBC userstores separate, i.e., the migration client
+                 should provide configurations for a Registry datasource and Primary JDBC userstore datasources
+                 and handle their migrations separately. */
+            if (isSeparateRegDB() && Objects.equals(getSchema(), "um")) {
                 conn = getDataSource("reg").getConnection();
                 migrateWithConnection(conn);
             }

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/SchemaMigrator.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/SchemaMigrator.java
@@ -67,7 +67,7 @@ public class SchemaMigrator extends Migrator {
             /* To support migration of registry and primary JDBC userstores separate, i.e., the migration client
             should provide configurations for a Registry datasource and Primary JDBC userstore datasources and handle
             their migrations separately. */
-            if (isSeparateRegDB() && Objects.equals(getSchema(), "um")) {
+            if (isSeparateRegistryDB() && Objects.equals(getSchema(), "um")) {
                 Map<String, DataSource> regDatasources = getRegistryDataSources();
                 for (Map.Entry<String, DataSource> dataSource : regDatasources.entrySet()) {
                     // Updating the 'conn' object for migration of registry data sources.

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/SchemaMigrator.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/SchemaMigrator.java
@@ -62,7 +62,7 @@ public class SchemaMigrator extends Migrator {
         this.location = getMigratorConfig().getParameterValue(Constant.LOCATION);
         try {
             conn = getDataSource().getConnection();
-            migrateWithConnection(conn);
+            migrateWithDBConnection(conn);
             /* To support migration of registry and primary JDBC userstores separate, i.e., the migration client
             should provide configurations for a Registry datasource and Primary JDBC userstore datasources and handle
             their migrations separately. */
@@ -70,7 +70,7 @@ public class SchemaMigrator extends Migrator {
                 Map<String, DataSource> regDatasources = getRegistryDataSources();
                 for (Map.Entry<String, DataSource> dataSource : regDatasources.entrySet()) {
                     conn = dataSource.getValue().getConnection();
-                     migrateWithConnection(conn);
+                     migrateWithDBConnection(conn);
                 }
             }
         } catch (SQLException e) {
@@ -78,7 +78,7 @@ public class SchemaMigrator extends Migrator {
         }
     }
 
-    private void migrateWithConnection(Connection conn) throws MigrationClientException {
+    private void migrateWithDBConnection(Connection conn) throws MigrationClientException {
 
         log.info(Constant.MIGRATION_LOG + "Executing Identity Migration Scripts.");
         try {

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/SchemaMigrator.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/SchemaMigrator.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.is.migration.util.Constant;
 import org.wso2.carbon.is.migration.util.Utility;
 import org.wso2.carbon.utils.dbcreator.DatabaseCreator;
 
+import javax.sql.DataSource;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -35,6 +36,7 @@ import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.text.NumberFormat;
 import java.text.ParsePosition;
+import java.util.Map;
 import java.util.Objects;
 import java.util.StringTokenizer;
 
@@ -62,11 +64,14 @@ public class SchemaMigrator extends Migrator {
             conn = getDataSource().getConnection();
             migrateWithConnection(conn);
             /* To support migration of registry and primary JDBC userstores separate, i.e., the migration client
-                 should provide configurations for a Registry datasource and Primary JDBC userstore datasources
-                 and handle their migrations separately. */
+            should provide configurations for a Registry datasource and Primary JDBC userstore datasources and handle
+            their migrations separately. */
             if (isSeparateRegDB() && Objects.equals(getSchema(), "um")) {
-                conn = getDataSource("reg").getConnection();
-                migrateWithConnection(conn);
+                Map<String, DataSource> regDatasources = getRegistryDataSources();
+                for (Map.Entry<String, DataSource> dataSource : regDatasources.entrySet()) {
+                    conn = dataSource.getValue().getConnection();
+                     migrateWithConnection(conn);
+                }
             }
         } catch (SQLException e) {
             throw new MigrationClientException(e.getMessage(), e);

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/Schema.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/Schema.java
@@ -22,8 +22,7 @@ public enum Schema {
     IDENTITY("identity"),
     UM("um"),
     CONSENT("consent"),
-    UMA("uma"),
-    REG("reg");
+    UMA("uma");
 
     private String schemaName;
 

--- a/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/Schema.java
+++ b/components/org.wso2.is.migration/migration-service/src/main/java/org/wso2/carbon/is/migration/util/Schema.java
@@ -22,7 +22,8 @@ public enum Schema {
     IDENTITY("identity"),
     UM("um"),
     CONSENT("consent"),
-    UMA("uma");
+    UMA("uma"),
+    REG("reg");
 
     private String schemaName;
 


### PR DESCRIPTION
**Purpose :**
> The migration client should be able to support migration of registry and primary JDBC userstores separate, i.e., the migration client should provide configurations for a Registry datasource and Primary JDBC userstore datasources and handle their migrations separately.

**Related Issue:**
- https://github.com/wso2/product-is/issues/15214